### PR TITLE
encrypting notes that are already linked to breaks the links because of the renaming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ You can install the plugin via the Community Plugins tab within Obsidian by sear
 
 > Please report any bugs or feature requests [here](https://github.com/meld-cp/obsidian-encrypt/issues).
 
+### 2.3.1
+- fix encrypt/decrypt of notes don't update links (#118)
+
 ### 2.3.0
 - add encrypt/decrypt of `.md` or `.encrypted` notes #68 (via file context menu, ribbon icon or command palette, helps with #91, #103, #108, #114)
 - fix double blank line #107

--- a/src/features/feature-convert-note/FeatureConvertNote.ts
+++ b/src/features/feature-convert-note/FeatureConvertNote.ts
@@ -198,9 +198,8 @@ export default class FeatureConvertNote implements IMeldEncryptPluginFeature {
 		});
 
 		try{
-			//return await this.updateFile( file, newFileExtension, content );
 			const newFilepath = Utils.getFilePathWithNewExtension(file, newFileExtension);
-			await app.vault.rename( file, newFilepath );
+			await app.fileManager.renameFile( file, newFilepath );
 			await app.vault.modify( file, content );
 			SessionPasswordService.putByFile( pw, file );
 		}finally{


### PR DESCRIPTION
Fixes #118