### PR TITLE
Allow editing and saving decrypted text when decrypting inline text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ node_modules
 dist
 *.map
 Obsidian Encrypt - test-vault
+test-vault
 

--- a/src/features/feature-inplace-encrypt/DecryptModal.ts
+++ b/src/features/feature-inplace-encrypt/DecryptModal.ts
@@ -3,6 +3,7 @@ import { App, Modal, Notice, Setting, TextAreaComponent } from 'obsidian';
 export default class DecryptModal extends Modal {
 	text: string;
 	decryptInPlace = false;
+	save = false;
 	
 	canDecryptInPlace = true;
 
@@ -28,13 +29,23 @@ export default class DecryptModal extends Modal {
 				cTextArea = cb;
 				cb.setValue(this.text);
 				cb.inputEl.setSelectionRange(0,0)
-				cb.inputEl.readOnly = true;
 				cb.inputEl.rows = 10;
 			})
 		;
 		sText.settingEl.querySelector('.setting-item-info')?.remove();
 
 		const sActions = new Setting(contentEl);
+
+		sActions
+			.addButton(cb => {
+				cb
+					.setButtonText('Save')
+					.onClick( evt =>{
+						this.save = true;
+						this.text = cTextArea.getValue();
+						this.close();
+					});
+			});
 
 		sActions
 			.addButton( cb =>{
@@ -53,6 +64,7 @@ export default class DecryptModal extends Modal {
 				.setButtonText('Decrypt in-place')
 				.onClick( evt =>{
 					this.decryptInPlace = true;
+					this.text = cTextArea.getValue();
 					this.close();
 				});
 			});

--- a/src/features/feature-inplace-encrypt/Decryptable.ts
+++ b/src/features/feature-inplace-encrypt/Decryptable.ts
@@ -2,4 +2,5 @@ export class Decryptable{
 	version: number;
 	base64CipherText:string;
 	hint:string;
+	showInReadingView: boolean;
 }

--- a/src/features/feature-inplace-encrypt/FeatureInplaceEncrypt.ts
+++ b/src/features/feature-inplace-encrypt/FeatureInplaceEncrypt.ts
@@ -609,11 +609,20 @@ export default class FeatureInplaceEncrypt implements IMeldEncryptPluginFeature{
 				editor.replaceSelection(decryptedText);
 			} else {
 				const decryptModal = new DecryptModal(this.plugin.app, '🔓', decryptedText );
-				decryptModal.onClose = () => {
+				decryptModal.onClose = async () => {
 					editor.focus();
 					if (decryptModal.decryptInPlace) {
 						editor.setSelection(selectionStart, selectionEnd);
-						editor.replaceSelection(decryptedText);
+						editor.replaceSelection(decryptModal.text);
+					} else if (decryptModal.save) {
+						const crypto = CryptoHelperFactory.BuildDefault();
+						const encodedText = this.encodeEncryption(
+							await crypto.encryptToBase64(decryptModal.text, password),
+							decryptable.hint ?? "",
+							decryptable.showInReadingView
+						);
+						editor.setSelection(selectionStart, selectionEnd);
+						editor.replaceSelection(encodedText);
 					}
 				}
 				decryptModal.open();

--- a/src/features/feature-inplace-encrypt/featureInplaceTextAnalysis.ts
+++ b/src/features/feature-inplace-encrypt/featureInplaceTextAnalysis.ts
@@ -91,7 +91,7 @@ export class FeatureInplaceTextAnalysis{
 		}else{
 			result.base64CipherText = content;
 		}
-		
+		result.showInReadingView = !this.prefix.includes("%%");
 		return result;
 
 	}


### PR DESCRIPTION
This PR allows editing decrypted inline text in the decryption modal and then re-encrypting and saving the edited text.