### PR TITLE
feat: support internal heading links in encrypted notes

### DIFF
--- a/src/features/feature-whole-note-encrypt/EncryptedMarkdownView.ts
+++ b/src/features/feature-whole-note-encrypt/EncryptedMarkdownView.ts
@@ -20,6 +20,8 @@ export class EncryptedMarkdownView extends MarkdownView {
 	override allowNoFile = false;
 
 	origFile:TFile | null; // used resync password cache when renaming the file
+
+	private _linksWired = false;
 	
 	override getViewType(): string {
 		return EncryptedMarkdownView.VIEW_TYPE;
@@ -113,12 +115,208 @@ export class EncryptedMarkdownView extends MarkdownView {
 				this.isSavingEnabled = true; // allow saving after the file is loaded with a password
 			}
 
+			this.wireInternalLinks();
+
 		}finally{
 			//console.debug('onLoadFile done');
 			this.setViewBusy( false );
 		}
 
 	}
+
+	private wireInternalLinks(): void {
+		if (this._linksWired) return;
+		this._linksWired = true;
+
+		const getSourcePath = () => this.file?.path ?? "";
+
+		// reading / rendered view: handle clicks on internal links
+		const readingRoot =
+		this.contentEl.querySelector<HTMLElement>(
+			".markdown-reading-view, .markdown-preview-view, .markdown-rendered"
+		) ?? this.contentEl;
+		this.registerDomEvent(
+		readingRoot,
+		"click",
+		(evt: MouseEvent) => {
+			const el = (evt.target as HTMLElement | null)?.closest(
+			"a.internal-link, .internal-link"
+			) as HTMLElement | null;
+			if (!el) return;
+			const raw = (
+			el.getAttribute("data-href") ||
+			(el as HTMLAnchorElement).getAttribute("href") ||
+			""
+			).trim();
+			if (!raw) return;
+			evt.preventDefault();
+
+			if (!raw.startsWith("#")) {
+			this.app.workspace.openLinkText(raw, getSourcePath(), false);
+			return;
+			}
+
+			const slug = decodeURIComponent(raw.slice(1));
+			// try id or data-heading match quickly
+			const target =
+			readingRoot.querySelector<HTMLElement>(
+				`[data-heading="${slug}"], #${CSS.escape(slug)}`
+			) ||
+			Array.from(
+				readingRoot.querySelectorAll<HTMLElement>("h1,h2,h3,h4,h5,h6")
+			).find((h) => {
+				const text = (h.getAttribute("data-heading") || h.textContent || "")
+				.trim()
+				.toLowerCase();
+				return text === slug.toLowerCase();
+			}) ||
+			null;
+			if (target) {
+			const scroller =
+				readingRoot.closest<HTMLElement>(".workspace-leaf .view-content") ??
+				readingRoot;
+			const offset =
+				(this.containerEl
+				.querySelector<HTMLElement>(
+					".view-header, .mod-top, .inline-title"
+				)
+				?.getBoundingClientRect().height ?? 0) + 8;
+			target.scrollIntoView({
+				behavior: "auto",
+				block: "start",
+				inline: "nearest",
+			});
+			requestAnimationFrame(() => {
+				scroller.scrollTop = Math.max(scroller.scrollTop - offset, 0);
+			});
+			return;
+			}
+
+			// fallback to normal openLinkText (lets Obsidian try)
+			this.app.workspace.openLinkText(raw, getSourcePath(), false);
+		},
+		{ capture: true }
+		);
+
+		// editor (source) — handle pointer events to resolve links under cursor
+		const inThisView = (n: Node | null) => !!n && this.containerEl.contains(n);
+		const isEditorEvent = (e: Event) =>
+		!!(e.target as HTMLElement | null)?.closest(
+			".markdown-source-view, .cm-editor, .cm-content"
+		);
+		const cm = (this as any).editor?.cm || null;
+		const posFromEvent = (evt: MouseEvent) =>
+		cm?.posAtCoords?.({ x: evt.clientX, y: evt.clientY }) ??
+		cm?.view?.posAtCoords?.({ x: evt.clientX, y: evt.clientY }) ??
+		null;
+
+		const slugify = (s: string) =>
+		s
+			.normalize("NFKD")
+			.replace(/[\u0300-\u036f]/g, "")
+			.replace(/\[[^\]]*\]\([^\)]*\)/g, "")
+			.replace(/[*_~]/g, "")
+			.replace(/#+$/g, "")
+			.trim()
+			.toLowerCase()
+			.replace(/[^\p{L}\p{N}\s-]+/gu, "")
+			.replace(/\s+/g, " ");
+
+		const findHeadingLineBySlug = (
+		cmInstance: any,
+		slug: string
+		): number | null => {
+		const doc = cmInstance?.state?.doc || cmInstance?.view?.state?.doc;
+		if (!doc) return null;
+		const key = slugify(slug.replace(/-/g, " "));
+		for (let i = 1; i <= doc.lines; i++) {
+			const ln = doc.line(i);
+			const m = ln.text.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
+			if (m && slugify(m[2]) === key) return i;
+		}
+		return null;
+		};
+
+		const revealEditorLine = (line1: number) => {
+		const editor = (this as any).editor;
+		if (!editor) return;
+		const line = Math.max(0, line1 - 1);
+		editor.setCursor({ line, ch: 0 });
+		editor.scrollIntoView(
+			{ from: { line, ch: 0 }, to: { line, ch: 0 } },
+			true
+		);
+		};
+
+		const handleEditorClick = (evt: MouseEvent) => {
+		if (!inThisView(evt.target as Node)) return;
+		if (!isEditorEvent(evt)) return;
+
+		const linkEl = (evt.target as HTMLElement | null)?.closest(
+			".cm-hmd-internal-link, a.internal-link, .internal-link"
+		) as HTMLElement | null;
+		if (!linkEl) return;
+
+		const pos = posFromEvent(evt);
+		if (pos == null) return;
+
+		const doc = cm?.state?.doc || cm?.view?.state?.doc;
+		if (!doc) return;
+		const line = doc.lineAt(pos);
+		// try to parse a link near the index: simple heuristics for wikilinks / md links / fallback #slug
+		const parseAround = (text: string, idx: number): string | null => {
+			const s = text.lastIndexOf("[[", idx),
+			e = text.indexOf("]]", idx);
+			if (s !== -1 && e !== -1 && e > s) {
+			const inside = text
+				.slice(s + 2, e)
+				.split("|")[0]
+				.trim();
+			if (inside)
+				return !inside.startsWith("#") &&
+				!inside.includes("#") &&
+				!inside.includes(".")
+				? `#${inside}`
+				: inside;
+			}
+			const mdRe = /\[[^\]]*?\]\(([^\)]+)\)/g;
+			let m: RegExpExecArray | null;
+			while ((m = mdRe.exec(text))) {
+			const a = m.index,
+				b = a + m[0].length;
+			if (idx >= a && idx <= b) {
+				const tgt = m[1].trim();
+				return !tgt.startsWith("#") &&
+				!tgt.includes("#") &&
+				!tgt.includes(".")
+				? `#${tgt}`
+				: tgt;
+			}
+			}
+			const m2 = text.match(/#([^\s#\]]+)/);
+			return m2 ? `#${m2[1]}` : null;
+		};
+
+		const linktext = parseAround(line.text, pos - line.from);
+
+		if (!linktext) return;
+		evt.preventDefault();
+
+		if (!linktext.startsWith("#")) {
+			this.app.workspace.openLinkText(linktext, getSourcePath(), false);
+			return;
+		}
+
+		const slug = decodeURIComponent(linktext.slice(1));
+		const targetLine = findHeadingLineBySlug(cm, slug);
+		if (targetLine != null) revealEditorLine(targetLine);
+		else this.app.workspace.openLinkText(linktext, getSourcePath(), false);
+		};
+
+		this.registerDomEvent(document, "pointerdown", handleEditorClick, {
+		capture: true,
+		});
+  	}
 
 	private setViewBusy( busy: boolean ) {
 		if ( busy ) {


### PR DESCRIPTION
Fixes #214 

handle internal links like [[#subtitle|Go to subtitle]]

Intercept clicks in both rendered and source views to support:
- Obsidian wiki links ([[#target|alias]])
- In-note anchors (#Heading) resolved by id, data-heading, or normalized heading text (case/diacritics-insensitive)
- File links opened via workspace.openLinkText with correct source path

Rendered view:
- Scroll to matching heading and compensate for header offset
- Use capture phase to preempt default handling; graceful fallback to openLinkText

Source editor:
- Detect link under cursor via CodeMirror posAtCoords
- Parse nearby wiki/MD link or fallback #slug
- Find heading line via custom slugify and reveal it; fallback to openLinkText if not found

Includes guards to avoid double wiring and limits handlers to the current view.

Test plan:
- In an encrypted note, clicking [[#Encabezado|Go]] jumps to the heading in rendered view
- In source view, clicking on links moves the cursor/viewport to the heading
