### PR TITLE
Display decrypted partial notes in Markdown format

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "meld-encrypt",
 	"name": "Meld Encrypt",
-	"version": "0.1.0",
+	"version": "2.4.6",
 	"minAppVersion": "1.0.3",
 	"description": "Hide secrets in your vault",
 	"author": "meld-cp",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "meld-encrypt",
 	"name": "Meld Encrypt",
-	"version": "2.4.5",
+	"version": "0.1.0",
 	"minAppVersion": "1.0.3",
 	"description": "Hide secrets in your vault",
 	"author": "meld-cp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,7 +518,6 @@
 			"integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.6",
 				"debug": "^4.3.1",
@@ -534,7 +533,6 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -546,7 +544,6 @@
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -560,7 +557,6 @@
 			"integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -571,7 +567,6 @@
 			"integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -585,7 +580,6 @@
 			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -610,7 +604,6 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -622,7 +615,6 @@
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -633,7 +625,6 @@
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -647,7 +638,6 @@
 			"integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -661,7 +651,6 @@
 			"integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -672,7 +661,6 @@
 			"integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@eslint/core": "^0.15.1",
 				"levn": "^0.4.1"
@@ -687,7 +675,6 @@
 			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -698,7 +685,6 @@
 			"integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@humanfs/core": "^0.19.1",
 				"@humanwhocodes/retry": "^0.3.0"
@@ -713,7 +699,6 @@
 			"integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=18.18"
 			},
@@ -728,7 +713,6 @@
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -743,7 +727,6 @@
 			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=18.18"
 			},
@@ -811,8 +794,7 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "24.0.13",
@@ -885,6 +867,7 @@
 			"integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.36.0",
 				"@typescript-eslint/types": "8.36.0",
@@ -1103,7 +1086,6 @@
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -1114,7 +1096,6 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -1145,7 +1126,6 @@
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -1161,8 +1141,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
-			"license": "Python-2.0",
-			"peer": true
+			"license": "Python-2.0"
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -1213,7 +1192,6 @@
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -1224,7 +1202,6 @@
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -1257,7 +1234,6 @@
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -1270,16 +1246,14 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -1287,7 +1261,6 @@
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -1320,8 +1293,7 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/emoji-regex": {
 			"version": "10.4.0",
@@ -1393,7 +1365,6 @@
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1469,7 +1440,6 @@
 			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -1500,7 +1470,6 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1512,7 +1481,6 @@
 			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -1526,7 +1494,6 @@
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -1537,7 +1504,6 @@
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -1551,7 +1517,6 @@
 			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"acorn": "^8.15.0",
 				"acorn-jsx": "^5.3.2",
@@ -1570,7 +1535,6 @@
 			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -1584,7 +1548,6 @@
 			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -1598,7 +1561,6 @@
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -1612,7 +1574,6 @@
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1623,7 +1584,6 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1633,8 +1593,7 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -1671,16 +1630,14 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
@@ -1698,7 +1655,6 @@
 			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"flat-cache": "^4.0.0"
 			},
@@ -1725,7 +1681,6 @@
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1743,7 +1698,6 @@
 			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.4"
@@ -1757,8 +1711,7 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -1788,7 +1741,6 @@
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -1802,7 +1754,6 @@
 			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -1823,7 +1774,6 @@
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1844,7 +1794,6 @@
 			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -1862,7 +1811,6 @@
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -1905,8 +1853,7 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -1914,7 +1861,6 @@
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -1927,24 +1873,21 @@
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
@@ -1952,7 +1895,6 @@
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -1963,7 +1905,6 @@
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -1978,7 +1919,6 @@
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -1994,8 +1934,7 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -2080,7 +2019,6 @@
 			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -2099,7 +2037,6 @@
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -2116,7 +2053,6 @@
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -2133,7 +2069,6 @@
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -2147,7 +2082,6 @@
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2158,7 +2092,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2182,7 +2115,6 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -2193,7 +2125,6 @@
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2225,7 +2156,6 @@
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -2284,7 +2214,6 @@
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -2298,7 +2227,6 @@
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2343,7 +2271,6 @@
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -2355,8 +2282,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
 			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -2364,7 +2290,6 @@
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -2411,7 +2336,6 @@
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -2425,6 +2349,7 @@
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2446,7 +2371,6 @@
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -2455,8 +2379,7 @@
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -2464,7 +2387,6 @@
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -2481,7 +2403,6 @@
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2560,7 +2481,6 @@
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "meld-encrypt",
-	"version": "2.4.5",
+	"version": "0.1.0",
 	"description": "Hide secrets in your vault",
 	"main": "main.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "meld-encrypt",
-	"version": "0.1.0",
+	"version": "2.4.6",
 	"description": "Hide secrets in your vault",
 	"main": "main.js",
 	"scripts": {

--- a/src/features/feature-inplace-encrypt/DecryptModal.ts
+++ b/src/features/feature-inplace-encrypt/DecryptModal.ts
@@ -8,6 +8,7 @@ export default class DecryptModal extends Modal {
 	canDecryptInPlace = true;
 	isPreviewMode = true; // Show preview by default
 	private cTextArea: TextAreaComponent | undefined;
+	private contentContainer: HTMLElement | undefined;
 
 	constructor(
 		app: App,
@@ -33,18 +34,18 @@ export default class DecryptModal extends Modal {
 					.setValue(this.isPreviewMode)
 					.onChange(value => {
 						this.isPreviewMode = value;
-						this.refreshContent(contentEl);
+						this.refreshContent();
 					});
 				toggle.toggleEl.setAttribute('aria-label', 'Toggle between preview and edit mode');
 			});
 		modeToggleSetting.nameEl.style.marginBottom = '0.5em';
 
 		// Container for preview or edit content
-		const contentContainer = document.createElement('div');
-		contentContainer.style.marginTop = '1em';
-		contentEl.appendChild(contentContainer);
+		this.contentContainer = document.createElement('div');
+		this.contentContainer.style.marginTop = '1em';
+		contentEl.appendChild(this.contentContainer);
 
-		this.refreshContent(contentEl, contentContainer);
+		this.refreshContent();
 
 		const sActions = new Setting(contentEl);
 
@@ -87,18 +88,12 @@ export default class DecryptModal extends Modal {
 		}
 	}
 
-	private refreshContent(contentEl: HTMLElement, contentContainer?: HTMLElement) {
-		// Find or create the content container
-		if (!contentContainer) {
-			contentContainer = contentEl.querySelector('.meld-decrypt-content-container') as HTMLElement;
-			if (!contentContainer) {
-				contentContainer = document.createElement('div');
-				contentContainer.classList.add('meld-decrypt-content-container');
-				contentEl.appendChild(contentContainer);
-			}
+	private refreshContent() {
+		if (!this.contentContainer) {
+			return;
 		}
 
-		contentContainer.empty();
+		this.contentContainer.empty();
 
 		if (this.isPreviewMode) {
 			// Render markdown preview
@@ -109,14 +104,14 @@ export default class DecryptModal extends Modal {
 			previewContainer.style.border = '1px solid var(--background-modifier-border)';
 			previewContainer.style.borderRadius = '4px';
 			previewContainer.style.padding = '8px';
-			contentContainer.appendChild(previewContainer);
+			this.contentContainer.appendChild(previewContainer);
 
 			// Use MarkdownRenderer to render the markdown content
 			const mdComponent = new Component();
 			MarkdownRenderer.renderMarkdown(this.text, previewContainer, '', mdComponent);
 		} else {
 			// Show edit mode with textarea
-			const setting = new Setting(contentContainer);
+			const setting = new Setting(this.contentContainer);
 			setting.addTextArea(cb => {
 				this.cTextArea = cb;
 				cb.setValue(this.text);
@@ -125,6 +120,8 @@ export default class DecryptModal extends Modal {
 				cb.inputEl.focus();
 				cb.onChange(value => {
 					this.text = value;
+					// Real-time update preview if we switch back to preview mode
+					// This ensures we're always working with the latest text
 				});
 			});
 			setting.settingEl.querySelector('.setting-item-info')?.remove();

--- a/src/features/feature-inplace-encrypt/DecryptModal.ts
+++ b/src/features/feature-inplace-encrypt/DecryptModal.ts
@@ -1,4 +1,4 @@
-import { App, Modal, Notice, Setting, TextAreaComponent } from 'obsidian';
+import { App, Component, Modal, Notice, Setting, TextAreaComponent, MarkdownRenderer } from 'obsidian';
 
 export default class DecryptModal extends Modal {
 	text: string;
@@ -6,6 +6,8 @@ export default class DecryptModal extends Modal {
 	save = false;
 	
 	canDecryptInPlace = true;
+	isPreviewMode = true; // Show preview by default
+	private cTextArea: TextAreaComponent | undefined;
 
 	constructor(
 		app: App,
@@ -23,16 +25,26 @@ export default class DecryptModal extends Modal {
 		contentEl.empty();
 		contentEl.classList.add('meld-encrypt-decrypt-modal');
 
-		let cTextArea : TextAreaComponent;
-		const sText = new Setting(contentEl)
-			.addTextArea( cb=>{
-				cTextArea = cb;
-				cb.setValue(this.text);
-				cb.inputEl.setSelectionRange(0,0)
-				cb.inputEl.rows = 10;
-			})
-		;
-		sText.settingEl.querySelector('.setting-item-info')?.remove();
+		// Create a toggle for preview/edit mode
+		const modeToggleSetting = new Setting(contentEl)
+			.setName('Display Mode')
+			.addToggle(toggle => {
+				toggle
+					.setValue(this.isPreviewMode)
+					.onChange(value => {
+						this.isPreviewMode = value;
+						this.refreshContent(contentEl);
+					});
+				toggle.toggleEl.setAttribute('aria-label', 'Toggle between preview and edit mode');
+			});
+		modeToggleSetting.nameEl.style.marginBottom = '0.5em';
+
+		// Container for preview or edit content
+		const contentContainer = document.createElement('div');
+		contentContainer.style.marginTop = '1em';
+		contentEl.appendChild(contentContainer);
+
+		this.refreshContent(contentEl, contentContainer);
 
 		const sActions = new Setting(contentEl);
 
@@ -42,7 +54,9 @@ export default class DecryptModal extends Modal {
 					.setButtonText('Save')
 					.onClick( evt =>{
 						this.save = true;
-						this.text = cTextArea.getValue();
+						if (this.cTextArea) {
+							this.text = this.cTextArea.getValue();
+						}
 						this.close();
 					});
 			});
@@ -52,7 +66,7 @@ export default class DecryptModal extends Modal {
 				cb
 					.setButtonText('Copy')
 					.onClick( evt =>{
-						navigator.clipboard.writeText( cTextArea.getValue() );
+						navigator.clipboard.writeText( this.text );
 						new Notice('Copied!');
 					})
 				;
@@ -64,12 +78,57 @@ export default class DecryptModal extends Modal {
 				.setButtonText('Decrypt in-place')
 				.onClick( evt =>{
 					this.decryptInPlace = true;
-					this.text = cTextArea.getValue();
+					if (this.cTextArea) {
+						this.text = this.cTextArea.getValue();
+					}
 					this.close();
 				});
 			});
 		}
+	}
 
+	private refreshContent(contentEl: HTMLElement, contentContainer?: HTMLElement) {
+		// Find or create the content container
+		if (!contentContainer) {
+			contentContainer = contentEl.querySelector('.meld-decrypt-content-container') as HTMLElement;
+			if (!contentContainer) {
+				contentContainer = document.createElement('div');
+				contentContainer.classList.add('meld-decrypt-content-container');
+				contentEl.appendChild(contentContainer);
+			}
+		}
+
+		contentContainer.empty();
+
+		if (this.isPreviewMode) {
+			// Render markdown preview
+			const previewContainer = document.createElement('div');
+			previewContainer.classList.add('markdown-preview-view');
+			previewContainer.style.maxHeight = '400px';
+			previewContainer.style.overflowY = 'auto';
+			previewContainer.style.border = '1px solid var(--background-modifier-border)';
+			previewContainer.style.borderRadius = '4px';
+			previewContainer.style.padding = '8px';
+			contentContainer.appendChild(previewContainer);
+
+			// Use MarkdownRenderer to render the markdown content
+			const mdComponent = new Component();
+			MarkdownRenderer.renderMarkdown(this.text, previewContainer, '', mdComponent);
+		} else {
+			// Show edit mode with textarea
+			const setting = new Setting(contentContainer);
+			setting.addTextArea(cb => {
+				this.cTextArea = cb;
+				cb.setValue(this.text);
+				cb.inputEl.setSelectionRange(0, 0);
+				cb.inputEl.rows = 10;
+				cb.inputEl.focus();
+				cb.onChange(value => {
+					this.text = value;
+				});
+			});
+			setting.settingEl.querySelector('.setting-item-info')?.remove();
+		}
 	}
 
 }


### PR DESCRIPTION
When decrypting partial notes, the resulting window only displayed the contents as raw text - this has been changed so that the contents will display in Markdown format.

To change to the editing mode, turn off the "Display Mode" button.

Display Mode:
<img width="550" height="395" alt="Screenshot 2026-03-12 at 12 16 20 PM" src="https://github.com/user-attachments/assets/128efd6e-2015-4520-a797-a32e010b9acf" />

Edit Mode:
<img width="547" height="345" alt="Screenshot 2026-03-12 at 12 18 11 PM" src="https://github.com/user-attachments/assets/bbb30620-c32d-4040-8793-424173f5e23a" />
