### PR TITLE
Add encrypted canvas support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,13 @@
 
 # npm
 node_modules
+.tools
+.test-build
 
 # build
 dist
 *.map
 Obsidian Encrypt - test-vault
 test-vault
-
+TESTVAULT
+SECURITY-TESTVAULT

--- a/docs/canvas-encryption.md
+++ b/docs/canvas-encryption.md
@@ -1,0 +1,124 @@
+# Encrypted Canvas design
+
+## Scope
+
+Meld Encrypt can protect the complete logical contents of selected `.canvas`
+files while retaining Obsidian's native Canvas editor. Decrypted Canvas data is
+passed directly to the native view and remains in the Obsidian process; the
+plugin does not create plaintext files or temporary plaintext copies.
+
+This feature is marked experimental because Obsidian does not expose its Canvas
+view/controller API publicly. Runtime feature detection fails closed when the
+required internals are unavailable.
+
+## Disk format
+
+Protected files remain valid Canvas JSON with empty public arrays:
+
+```json
+{
+  "nodes": [],
+  "edges": [],
+  "meldEncryptedCanvas": {
+    "format": "meld-encrypted-canvas",
+    "version": 1,
+    "payload": {
+      "version": "2.0",
+      "hint": "...",
+      "encodedData": "..."
+    }
+  }
+}
+```
+
+The encrypted payload contains the entire original Canvas object, including
+unknown top-level fields. Encryption uses Meld's existing `FileDataHelper` and
+current crypto format; this feature does not introduce separate cryptography.
+
+## Load and save boundaries
+
+The plugin discovers the native Canvas prototype at runtime and intercepts its
+`onLoadFile`, `setViewData`, `getViewData`, `save`, and unload lifecycle:
+
+- encrypted input is decoded in RAM and applied through `canvas.setData()`;
+- native `getViewData()` exposes only the encrypted wrapper for protected files;
+- every protected save obtains native Canvas data in RAM, encrypts and verifies
+  it, then lets the native save path write the wrapper;
+- saves are serialized, and the disk wrapper must still match the exact bytes
+  last loaded or written by that view;
+- a second view for the same protected path is rejected;
+- an external reload cannot replace an unlocked RAM state silently.
+
+Normal, unprotected Canvas files pass through unchanged.
+
+## Defense in depth
+
+For known protected paths, wrappers around `Vault.modify` and the adapter's
+`write`, `append`, and `writeBinary` methods reject non-encrypted writes. Corrupt
+files with the Meld Canvas marker remain protected. File and folder rename
+events migrate the protected-path state.
+
+The write guards protect normal Obsidian persistence and cooperating plugins.
+They cannot constrain a malicious plugin running in the same process that uses
+Node/Electron filesystem APIs directly.
+
+## User operations
+
+Commands and file-menu actions support:
+
+- encrypting an open or closed Canvas;
+- changing its password;
+- locking and closing one or all protected Canvases;
+- permanently decrypting after an explicit plaintext-write confirmation.
+
+Every encryption, password change, and conversion verifies the new ciphertext
+by decrypting and comparing it before replacing the disk file. Passwords use
+the existing `SessionPasswordService` and Meld password dialog.
+
+## Embedded private content
+
+When an image is pasted into an unlocked encrypted Canvas, Meld intercepts the
+clipboard event before Obsidian creates a vault attachment. The image is stored
+as an in-memory data URL inside a native text card; consequently its bytes are
+part of the authenticated encrypted Canvas payload on disk.
+
+If Obsidian or another plugin creates an attachment before the interception can
+run, Meld tracks newly created image files while the encrypted Canvas is active.
+A referenced image is embedded on the next save and the original attachment is
+permanently deleted only after the encrypted wrapper has been decrypted for
+verification, written, and read back byte-for-byte from disk. Pre-existing image
+files are never deleted by this fallback.
+
+File cards referring to `.mdenc` or `.encrypted` notes are decrypted with the
+Canvas password and converted to native text cards in RAM. Notes encrypted with
+a different password remain file cards and a notice is shown. The source note
+itself remains encrypted and is not deleted or modified.
+
+An encrypted Canvas may also contain deliberate plaintext references. Normal
+vault file cards (including `.md` notes and existing images) remain external and
+are stored neither in nor under the Canvas encryption. Meld records
+`meldUnencrypted: true` on these cards and displays an `UNENCRYPTED` badge.
+Pasting an image normally embeds it securely; holding `Alt` while pasting lets
+Obsidian create a normal plaintext attachment instead. Such explicitly
+unencrypted attachments are excluded from the encrypted-image deletion fallback.
+
+## Security boundary
+
+"RAM-only" means Meld and the native Canvas save path do not intentionally
+write plaintext application files. JavaScript cannot guarantee memory
+zeroization, and operating-system swap, hibernation, crash dumps, memory
+forensics, or malicious same-process plugins are outside this guarantee.
+
+Encrypted Canvas contents do not appear in normal disk-based Canvas indexing.
+While a Canvas is unlocked, another plugin in the same Obsidian process can
+read its native in-memory Canvas object.
+
+## Compatibility and testing
+
+The private members currently required are `CanvasView.canvas`,
+`getViewData`, `setViewData`, `save`, `onLoadFile`, `onUnloadFile`, and
+`Canvas.getData/setData/requestSave`. Compatibility was exercised in isolated
+desktop instances of Obsidian 1.12.7 and 1.13.7. Mobile remains unverified.
+
+See [the security test report](canvas-security-test-report.md) for automated and
+runtime results and the remaining limits.

--- a/docs/canvas-security-test-report.md
+++ b/docs/canvas-security-test-report.md
@@ -1,0 +1,99 @@
+# Encrypted Canvas security test report
+
+Date: 2026-08-30
+
+## Automated results
+
+The wrapper test suite passes eight tests:
+
+- complete Canvas roundtrip, including unknown fields and Unicode;
+- wrong-password rejection;
+- damaged-wrapper rejection;
+- authenticated-ciphertext corruption rejection;
+- roundtrips in the 100 KB, 1 MB, 5 MB, and 10 MB size classes.
+
+The 10 MB-class roundtrip completes below the deliberately generous 30-second
+test ceiling. The suite uses Meld's unchanged `FileDataHelper` and default
+crypto version rather than a test cipher.
+
+The final filesystem watcher sampled an encrypted fixture 199 times at 100 ms
+intervals while saving and closing Obsidian. Every sample was valid wrapper JSON
+with empty public `nodes` and `edges`, and a full recursive scan of the security
+test vault found no plaintext test marker.
+
+## Implemented hardening
+
+- The whole logical Canvas object is encrypted as one payload.
+- Every conversion and password change performs encrypt → decrypt → compare
+  before replacing the disk file.
+- Protected saves are serialized through a promise queue.
+- The on-disk wrapper is compared byte-for-byte before every save to stop stale
+  Sync/NAS overwrites.
+- `Vault.modify`, adapter `write`, `append`, and `writeBinary` fail closed for
+  protected paths.
+- Protected `CanvasView.getViewData()` always returns ciphertext, including to
+  potential File Recovery callers. Plaintext is obtained only from the native
+  Canvas object in plugin-controlled code.
+- Plugin unload saves and closes protected views before removing patches.
+- A second view of the same protected path is rejected.
+- File and folder renames migrate protected state.
+- Corrupt wrappers carrying the Meld Canvas format marker are marked protected
+  so native empty-Canvas saves cannot overwrite them.
+- Error logs contain paths, byte counts, and error types only, never Canvas data
+  or error messages that might quote input.
+
+## Obsidian runtime results
+
+The tests ran in a disposable, isolated GUI profile first on the official
+Obsidian 1.12.7 AppImage and again after its official 1.13.7 application update.
+The following behavior was observed:
+
+- opening a protected Canvas produced exactly one password dialog and restored
+  all three nodes, one edge, unknown top-level data, and the secret test marker;
+- `CanvasView.getViewData()` returned the encrypted wrapper while the native
+  Canvas object held plaintext in RAM;
+- 20 rapid `setData()`/`requestSave()` operations were serialized and the last
+  generation persisted without a plaintext watcher sample;
+- an externally changed wrapper was not loaded over the unlocked RAM state and
+  the subsequent stale save was rejected; after explicitly restoring the
+  expected disk version, a direct save succeeded;
+- disabling the plugin immediately after `requestSave()` closed the protected
+  leaf, left ciphertext on disk, and preserved the last generation after
+  re-enabling and unlocking;
+- a complete process close and restart preserved the final generation; the
+  restart test also passed under Obsidian 1.13.7;
+- the enabled File Recovery core plugin stored a forced snapshot returned by
+  the protected serialization path as ciphertext. Its IndexedDB record did not
+  contain either known plaintext test marker;
+- recursive byte searches of the isolated profile and entire test vault found
+  neither known plaintext marker.
+
+The runtime tests exposed and led to fixes for initial layout discovery,
+Obsidian's `onLoadFile` path, concurrent load prompts, external reloads, and the
+fact that Obsidian does not await asynchronous plugin unload before a plugin can
+be enabled again.
+
+## Remaining limits
+
+- Mobile Canvas internals have not been tested on an Android or iOS device.
+- An operating-system crash, forced power loss, swap/hibernation, core dumps,
+  and memory-forensics resistance are outside this plugin-level test.
+- A third-party plugin that bypasses Obsidian's Vault/adapter objects and writes
+  directly through Node/Electron filesystem APIs cannot be intercepted here.
+- File Recovery was tested through its active 1.12.7/1.13.7 implementation and
+  IndexedDB API, but future proprietary implementation changes require another
+  compatibility test.
+
+## Reproduction
+
+```bash
+export PATH="$PWD/.tools/node-v24.20.0-linux-x64/bin:$PATH"
+npm run test:canvas
+npm run build
+npm run test:canvas-security-watch -- \
+  SECURITY-TESTVAULT Security.canvas \
+  MELD_CANVAS_TEST_SECRET_93c5421 60 200
+```
+
+The watcher should run while editing, autosaving, renaming, closing, reloading
+the plugin, and exiting Obsidian.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"test:canvas": "esbuild tests/canvas-encryption-wrapper.test.ts --bundle --platform=node --format=cjs --outfile=.test-build/canvas-encryption-wrapper.test.cjs && node .test-build/canvas-encryption-wrapper.test.cjs",
+		"test:canvas-security-watch": "node tools/canvas-security-watch.mjs",
+		"test:canvas-fixture": "esbuild tools/create-encrypted-canvas-fixture.ts --bundle --platform=node --format=cjs --outfile=.test-build/create-encrypted-canvas-fixture.cjs && node .test-build/create-encrypted-canvas-fixture.cjs",
 		"version": "node version-bump.mjs",
 		"dev-tool-decrypt": "tsc -noEmit -skipLibCheck && node esbuild-tool-decrypt.config.mjs",
 		"build-tool-decrypt": "tsc -noEmit -skipLibCheck && node esbuild-tool-decrypt.config.mjs production",

--- a/src/features/IMeldEncryptPluginFeature.ts
+++ b/src/features/IMeldEncryptPluginFeature.ts
@@ -3,7 +3,7 @@ import { IMeldEncryptPluginSettings } from "../settings/MeldEncryptPluginSetting
 
 export interface IMeldEncryptPluginFeature {
 	onload(plugin: MeldEncrypt, settings: IMeldEncryptPluginSettings): Promise<void>;
-	onunload(): void;
+	onunload(): void | Promise<void>;
 	buildSettingsUi(
 		containerEl: HTMLElement,
 		saveSettingCallback : () => Promise<void>

--- a/src/features/feature-canvas-encrypt/CanvasConfirmationModal.ts
+++ b/src/features/feature-canvas-encrypt/CanvasConfirmationModal.ts
@@ -1,0 +1,35 @@
+import { App, Modal, Setting } from 'obsidian';
+
+export class CanvasConfirmationModal extends Modal {
+	private resolve: ((confirmed: boolean) => void) | null = null;
+	private confirmed = false;
+
+	constructor(app: App, private heading: string, private warning: string, private confirmText: string) {
+		super(app);
+	}
+
+	onOpen(): void {
+		this.contentEl.empty();
+		new Setting(this.contentEl).setHeading().setName(this.heading);
+		this.contentEl.createEl('p', { text: this.warning });
+		new Setting(this.contentEl)
+			.addButton(button => button.setButtonText('Cancel').onClick(() => this.close()))
+			.addButton(button => button.setWarning().setButtonText(this.confirmText).onClick(() => {
+				this.confirmed = true;
+				this.close();
+			}));
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+		this.resolve?.(this.confirmed);
+		this.resolve = null;
+	}
+
+	openAsync(): Promise<boolean> {
+		return new Promise(resolve => {
+			this.resolve = resolve;
+			this.open();
+		});
+	}
+}

--- a/src/features/feature-canvas-encrypt/CanvasEmbeddedContent.ts
+++ b/src/features/feature-canvas-encrypt/CanvasEmbeddedContent.ts
@@ -1,0 +1,127 @@
+import { TFile, type App } from 'obsidian';
+import { ENCRYPTED_FILE_EXTENSIONS } from '../../services/Constants.ts';
+import { FileDataHelper, JsonFileEncoding } from '../../services/FileDataHelper.ts';
+import type { CanvasData } from './CanvasTypes.ts';
+
+const IMAGE_EXTENSIONS = new Set([
+	'avif', 'bmp', 'gif', 'jpeg', 'jpg', 'png', 'svg', 'webp',
+]);
+
+const MIME_TYPES: Record<string, string> = {
+	avif: 'image/avif', bmp: 'image/bmp', gif: 'image/gif', jpeg: 'image/jpeg',
+	jpg: 'image/jpeg', png: 'image/png', svg: 'image/svg+xml', webp: 'image/webp',
+};
+
+interface FileNode extends Record<string, unknown> {
+	type: 'file';
+	file: string;
+}
+
+export function markUnencryptedFileNodes(data: CanvasData): { data: CanvasData; changed: boolean } {
+	let changed = false;
+	const nodes = data.nodes.map(node => {
+		if (!isFileNode(node)) return node;
+		const extension = node.file.split('.').pop()?.toLowerCase() ?? '';
+		if (ENCRYPTED_FILE_EXTENSIONS.includes(extension) || node.meldUnencrypted === true) return node;
+		changed = true;
+		return { ...node, meldUnencrypted: true };
+	});
+	return { data: changed ? { ...data, nodes } : data, changed };
+}
+
+export function isUnencryptedFileNodeData(data: Record<string, unknown>): boolean {
+	if (data.type !== 'file' || typeof data.file !== 'string') return false;
+	const extension = data.file.split('.').pop()?.toLowerCase() ?? '';
+	return !ENCRYPTED_FILE_EXTENSIONS.includes(extension);
+}
+
+export function isImagePath(path: string): boolean {
+	const extension = path.split('.').pop()?.toLowerCase() ?? '';
+	return IMAGE_EXTENSIONS.has(extension);
+}
+
+export function arrayBufferToDataUrl(data: ArrayBuffer, mimeType: string): string {
+	const bytes = new Uint8Array(data);
+	let binary = '';
+	const chunkSize = 0x8000;
+	for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+		binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+	}
+	return `data:${mimeType};base64,${btoa(binary)}`;
+}
+
+export function imageFileToMarkdown(file: File): Promise<string> {
+	return file.arrayBuffer().then(data => {
+		const mime = file.type.startsWith('image/') ? file.type : 'image/png';
+		return `![${escapeMarkdownLabel(file.name || 'Pasted image')}](${arrayBufferToDataUrl(data, mime)})`;
+	});
+}
+
+export async function hydrateEncryptedNotes(
+	app: App, data: CanvasData, password: string,
+): Promise<{ data: CanvasData; failedPaths: string[]; hydratedPaths: string[] }> {
+	const failedPaths: string[] = [];
+	const hydratedPaths: string[] = [];
+	const nodes = await Promise.all(data.nodes.map(async node => {
+		if (!isFileNode(node)) return node;
+		const extension = node.file.split('.').pop()?.toLowerCase() ?? '';
+		if (!ENCRYPTED_FILE_EXTENSIONS.includes(extension)) return node;
+		const file = app.vault.getAbstractFileByPath(node.file);
+		if (!(file instanceof TFile)) return node;
+		try {
+			const encoded = JsonFileEncoding.decode(await app.vault.read(file));
+			const text = await FileDataHelper.decrypt(encoded, password);
+			if (text === null) {
+				failedPaths.push(node.file);
+				return node;
+			}
+			hydratedPaths.push(node.file);
+			const { type: _type, file: sourcePath, subpath: _subpath, ...rest } = node;
+			return {
+				...rest,
+				type: 'text',
+				text,
+				meldEncryptedSource: { kind: 'note', path: sourcePath },
+			};
+		} catch {
+			failedPaths.push(node.file);
+			return node;
+		}
+	}));
+	return { data: { ...data, nodes }, failedPaths, hydratedPaths };
+}
+
+export async function embedPendingImages(
+	app: App, data: CanvasData, pendingPaths: ReadonlySet<string>,
+): Promise<{ data: CanvasData; embeddedPaths: string[] }> {
+	const embeddedPaths: string[] = [];
+	const nodes = await Promise.all(data.nodes.map(async node => {
+		if (!isFileNode(node) || node.meldUnencrypted === true
+			|| !pendingPaths.has(node.file) || !isImagePath(node.file)) return node;
+		const file = app.vault.getAbstractFileByPath(node.file);
+		if (!(file instanceof TFile)) return node;
+		const extension = file.extension.toLowerCase();
+		const markdown = `![${escapeMarkdownLabel(file.name)}](${arrayBufferToDataUrl(
+			await app.vault.readBinary(file), MIME_TYPES[extension] ?? 'application/octet-stream',
+		)})`;
+		const { type: _type, file: sourcePath, subpath: _subpath, ...rest } = node;
+		embeddedPaths.push(sourcePath);
+		return {
+			...rest,
+			type: 'text',
+			text: markdown,
+			meldEncryptedSource: { kind: 'image', name: file.name },
+		};
+	}));
+	return { data: { ...data, nodes }, embeddedPaths };
+}
+
+function isFileNode(node: unknown): node is FileNode {
+	if (typeof node !== 'object' || node === null) return false;
+	const candidate = node as { type?: unknown; file?: unknown };
+	return candidate.type === 'file' && typeof candidate.file === 'string';
+}
+
+function escapeMarkdownLabel(value: string): string {
+	return value.replace(/\r\n|\r|\n/g, ' ').replace(/[\\\]]/g, match => `\\${match}`);
+}

--- a/src/features/feature-canvas-encrypt/CanvasEncryptionWrapper.ts
+++ b/src/features/feature-canvas-encrypt/CanvasEncryptionWrapper.ts
@@ -1,0 +1,82 @@
+import { FileData, FileDataHelper } from '../../services/FileDataHelper.ts';
+import { assertCanvasData, type CanvasData } from './CanvasTypes.ts';
+
+const FORMAT = 'meld-encrypted-canvas';
+const VERSION = 1;
+
+export interface EncryptedCanvasWrapper {
+	nodes: [];
+	edges: [];
+	meldEncryptedCanvas: {
+		format: typeof FORMAT;
+		version: typeof VERSION;
+		payload: FileData;
+	};
+}
+
+export function hasEncryptedCanvasMarker(text: string): boolean {
+	try {
+		const value: unknown = JSON.parse(text);
+		if (typeof value !== 'object' || value === null) return false;
+		const marker = (value as { meldEncryptedCanvas?: unknown }).meldEncryptedCanvas;
+		return typeof marker === 'object' && marker !== null
+			&& (marker as { format?: unknown }).format === FORMAT;
+	} catch {
+		return false;
+	}
+}
+
+export function decodeEncryptedCanvasWrapper(text: string): EncryptedCanvasWrapper | null {
+	let value: unknown;
+	try {
+		value = JSON.parse(text);
+	} catch {
+		return null;
+	}
+	if (typeof value !== 'object' || value === null) return null;
+	const candidate = value as Partial<EncryptedCanvasWrapper>;
+	const marker = candidate.meldEncryptedCanvas;
+	if (!Array.isArray(candidate.nodes) || candidate.nodes.length !== 0
+		|| !Array.isArray(candidate.edges) || candidate.edges.length !== 0
+		|| marker?.format !== FORMAT || marker.version !== VERSION
+		|| typeof marker.payload !== 'object' || marker.payload === null
+		|| typeof marker.payload.version !== 'string'
+		|| typeof marker.payload.hint !== 'string'
+		|| typeof marker.payload.encodedData !== 'string') return null;
+	return candidate as EncryptedCanvasWrapper;
+}
+
+export function isEncryptedCanvasWrapper(text: string): boolean {
+	return decodeEncryptedCanvasWrapper(text) !== null;
+}
+
+export async function encryptCanvasData(data: CanvasData, password: string, hint: string): Promise<string> {
+	assertCanvasData(data);
+	const plaintext = JSON.stringify(data);
+	const payload = await FileDataHelper.encrypt(password, hint, plaintext);
+	const wrapper: EncryptedCanvasWrapper = {
+		nodes: [],
+		edges: [],
+		meldEncryptedCanvas: { format: FORMAT, version: VERSION, payload },
+	};
+	return JSON.stringify(wrapper, null, 2);
+}
+
+export async function decryptCanvasData(wrapper: EncryptedCanvasWrapper, password: string): Promise<CanvasData | null> {
+	const plaintext = await FileDataHelper.decrypt(wrapper.meldEncryptedCanvas.payload, password);
+	if (plaintext === null) return null;
+	const value: unknown = JSON.parse(plaintext);
+	assertCanvasData(value);
+	return value;
+}
+
+export async function verifyEncryptedCanvas(
+	wrapperText: string,
+	password: string,
+	expectedData: CanvasData,
+): Promise<boolean> {
+	const wrapper = decodeEncryptedCanvasWrapper(wrapperText);
+	if (wrapper === null) return false;
+	const decrypted = await decryptCanvasData(wrapper, password);
+	return decrypted !== null && JSON.stringify(decrypted) === JSON.stringify(expectedData);
+}

--- a/src/features/feature-canvas-encrypt/CanvasPatcher.ts
+++ b/src/features/feature-canvas-encrypt/CanvasPatcher.ts
@@ -1,0 +1,432 @@
+import { Notice, TFile, type App } from 'obsidian';
+import type { PasswordAndHint } from '../../services/SessionPasswordService.ts';
+import {
+	decodeEncryptedCanvasWrapper, decryptCanvasData, encryptCanvasData,
+	isEncryptedCanvasWrapper, verifyEncryptedCanvas, type EncryptedCanvasWrapper,
+} from './CanvasEncryptionWrapper.ts';
+import { assertCanvasData, isNativeCanvasView, type CanvasData, type NativeCanvasView } from './CanvasTypes.ts';
+import {
+	embedPendingImages, hydrateEncryptedNotes, imageFileToMarkdown, isImagePath, markUnencryptedFileNodes,
+	isUnencryptedFileNodeData,
+} from './CanvasEmbeddedContent.ts';
+
+type CanvasMethod = (...args: never[]) => unknown;
+type CanvasPrototype = Record<string, CanvasMethod>;
+type PasswordResolver = (file: TFile, hint: string, forcePrompt: boolean) => Promise<PasswordAndHint | null>;
+
+interface ViewState {
+	passwordAndHint: PasswordAndHint | null;
+	wrapperText: string;
+	savingEnabled: boolean;
+	saveQueue: Promise<void>;
+	loadGeneration: number;
+	loadInProgress: boolean;
+	pendingImagePaths: Set<string>;
+	allowUnencryptedImageUntil: number;
+}
+
+export class CanvasPatcher {
+	private prototype: CanvasPrototype | null = null;
+	private vaultWriteGuardInstalled = false;
+	private restorers: Array<() => void> = [];
+	private protectedPaths = new Set<string>();
+	private states = new WeakMap<NativeCanvasView, ViewState>();
+	private openViewsByPath = new Map<string, NativeCanvasView>();
+	private acceptingLoads = true;
+
+	constructor(private app: App, private resolvePassword: PasswordResolver) {}
+
+	installWriteGuard(): void {
+		if (this.vaultWriteGuardInstalled) return;
+		this.patchVaultWrites();
+		this.vaultWriteGuardInstalled = true;
+	}
+
+	isInstalled(): boolean { return this.prototype !== null; }
+	hasProtectedFiles(): boolean { return this.protectedPaths.size > 0; }
+	hasViewState(view: NativeCanvasView): boolean { return this.states.has(view); }
+	stopAcceptingLoads(): void { this.acceptingLoads = false; }
+
+	tryInstall(view: unknown): boolean {
+		if (!isNativeCanvasView(view)) return false;
+		if (this.prototype !== null) return true;
+		this.prototype = Object.getPrototypeOf(view) as CanvasPrototype;
+		this.patchCanvasPrototype();
+		this.installWriteGuard();
+		console.info('Meld encrypted Canvas hooks installed', {
+			methods: ['getViewData', 'setViewData', 'save'],
+		});
+		return true;
+	}
+
+	markProtected(file: TFile): void { this.protectedPaths.add(file.path); }
+	unmarkProtected(file: TFile): void { this.protectedPaths.delete(file.path); }
+	isProtected(file: TFile | null): boolean { return file !== null && this.protectedPaths.has(file.path); }
+
+	registerUnlocked(view: NativeCanvasView, wrapperText: string, passwordAndHint: PasswordAndHint): void {
+		this.states.set(view, {
+			passwordAndHint, wrapperText, savingEnabled: true,
+			saveQueue: Promise.resolve(), loadGeneration: 0, loadInProgress: false,
+			pendingImagePaths: new Set(), allowUnencryptedImageUntil: 0,
+		});
+		if (view.file !== null) this.markProtected(view.file);
+	}
+
+	trackCreatedImage(view: NativeCanvasView, file: TFile): void {
+		const state = this.states.get(view);
+		if (state?.savingEnabled && isImagePath(file.path)
+			&& Date.now() > state.allowUnencryptedImageUntil) state.pendingImagePaths.add(file.path);
+	}
+
+	allowNextCreatedImageUnencrypted(view: NativeCanvasView): void {
+		const state = this.states.get(view);
+		if (state?.savingEnabled) state.allowUnencryptedImageUntil = Date.now() + 5_000;
+	}
+
+	async handleImagePaste(view: NativeCanvasView, event: ClipboardEvent): Promise<boolean> {
+		const state = this.states.get(view);
+		const createTextNode = view.canvas.createTextNode;
+		if (!state?.savingEnabled || state.passwordAndHint === null || typeof createTextNode !== 'function') return false;
+		const image = Array.from(event.clipboardData?.files ?? []).find(file => file.type.startsWith('image/'));
+		if (image === undefined) return false;
+		const text = await imageFileToMarkdown(image);
+		const pos = typeof view.canvas.posFromEvt === 'function'
+			? view.canvas.posFromEvt(event as unknown as MouseEvent) : { x: 0, y: 0 };
+		createTextNode.call(view.canvas, { pos, size: { width: 400, height: 300 }, text });
+		view.canvas.requestSave();
+		return true;
+	}
+
+	async assertDiskUnchanged(view: NativeCanvasView): Promise<void> {
+		if (view.file === null) throw new Error('Canvas file is unavailable');
+		const state = this.states.get(view);
+		if (state === undefined || state.wrapperText.length === 0) {
+			throw new Error('Encrypted Canvas state is unavailable');
+		}
+		const currentDiskText = await this.app.vault.read(view.file);
+		if (currentDiskText !== state.wrapperText) {
+			throw new Error(`Encrypted Canvas changed externally: ${view.file.path}`);
+		}
+	}
+
+	disable(view: NativeCanvasView): void {
+		const state = this.states.get(view);
+		if (state === undefined) return;
+		state.savingEnabled = false;
+		state.passwordAndHint = null;
+		state.wrapperText = '';
+	}
+
+	rename(oldPath: string, newPath: string): void {
+		if (this.protectedPaths.delete(oldPath)) this.protectedPaths.add(newPath);
+		const view = this.openViewsByPath.get(oldPath);
+		if (view !== undefined) {
+			this.openViewsByPath.delete(oldPath);
+			this.openViewsByPath.set(newPath, view);
+		}
+	}
+
+	renameFolder(oldPath: string, newPath: string): void {
+		const prefix = `${oldPath}/`;
+		for (const path of [...this.protectedPaths]) {
+			if (!path.startsWith(prefix)) continue;
+			this.rename(path, `${newPath}/${path.slice(prefix.length)}`);
+		}
+	}
+
+	uninstall(): void {
+		for (const restore of this.restorers.reverse()) restore();
+		this.restorers = [];
+		this.prototype = null;
+		this.vaultWriteGuardInstalled = false;
+		this.protectedPaths.clear();
+		this.openViewsByPath.clear();
+	}
+
+	private patchCanvasPrototype(): void {
+		const patcher = this;
+		const originalGetViewData = this.prototype?.getViewData;
+		if (typeof originalGetViewData !== 'function') throw new Error('Canvas getViewData is unavailable');
+
+		this.patch('setViewData', original => function(this: NativeCanvasView, data: string, clear: boolean): void {
+			const currentState = patcher.states.get(this);
+			if (patcher.isProtected(this.file) && currentState?.savingEnabled) {
+				if (data !== currentState.wrapperText) {
+					new Notice(`Encrypted Canvas changed externally; reload blocked: ${this.file?.path ?? 'unknown file'}`, 0);
+				}
+				return;
+			}
+			const wrapper = decodeEncryptedCanvasWrapper(data);
+			if (wrapper === null) {
+				if (patcher.isProtected(this.file)) {
+					new Notice(`Refused invalid encrypted Canvas data: ${this.file?.path ?? 'unknown file'}`);
+					return;
+				}
+				original.call(this, data, clear);
+				return;
+			}
+			const generation = patcher.prepareEncryptedLoad(this, data);
+			if (generation === null) return;
+			original.call(this, '{"nodes":[],"edges":[]}', true);
+			void patcher.unlockAndLoad(
+				this, wrapper, data, generation,
+				canvasData => original.call(this, JSON.stringify(canvasData), clear),
+			);
+		});
+
+		if (typeof this.prototype?.onLoadFile === 'function') {
+			this.patch('onLoadFile', original => async function(this: NativeCanvasView, file: TFile): Promise<void> {
+				const currentState = patcher.states.get(this);
+				if (patcher.isProtected(file) && currentState?.savingEnabled) {
+					const diskText = await patcher.app.vault.read(file);
+					if (diskText !== currentState.wrapperText) {
+						new Notice(`Encrypted Canvas changed externally; reload blocked: ${file.path}`, 0);
+					}
+					return;
+				}
+				await original.call(this, file);
+				if (!patcher.isProtected(file) || patcher.states.has(this)) return;
+				const wrapperText = await patcher.app.vault.read(file);
+				const wrapper = decodeEncryptedCanvasWrapper(wrapperText);
+				if (wrapper === null) {
+					new Notice(`Encrypted Canvas wrapper is invalid: ${file.path}`);
+					return;
+				}
+				const generation = patcher.prepareEncryptedLoad(this, wrapperText);
+				if (generation === null) return;
+				await patcher.unlockAndLoad(
+					this, wrapper, wrapperText, generation,
+					canvasData => this.canvas.setData(canvasData),
+				);
+			});
+		}
+
+		this.patch('getViewData', original => function(this: NativeCanvasView): string {
+			if (!patcher.isProtected(this.file)) return original.call(this) as string;
+			const state = patcher.states.get(this);
+			if (state?.wrapperText && isEncryptedCanvasWrapper(state.wrapperText)) {
+				return state.wrapperText;
+			}
+			throw new Error(`Encrypted Canvas serialization is unavailable: ${this.file?.path ?? 'unknown file'}`);
+		});
+
+		this.patch('save', original => async function(this: NativeCanvasView, clear?: boolean): Promise<void> {
+			if (!patcher.isProtected(this.file)) {
+				await original.call(this, clear);
+				return;
+			}
+			const state = patcher.states.get(this);
+			if (state === undefined || !state.savingEnabled || state.passwordAndHint === null) {
+				console.info('Meld encrypted Canvas save blocked while locked', { path: this.file?.path });
+				return;
+			}
+			const queuedSave = async (): Promise<void> => {
+				await patcher.assertDiskUnchanged(this);
+				const plaintext = originalGetViewData.call(this) as string;
+				const data: unknown = JSON.parse(plaintext);
+				assertCanvasData(data);
+				const credentials = state.passwordAndHint;
+				if (credentials === null) throw new Error('Canvas password is unavailable');
+				const hydrated = await hydrateEncryptedNotes(patcher.app, data, credentials.password);
+				if (hydrated.failedPaths.length > 0) new Notice('Some encrypted notes use a different password and remain locked');
+				const embedded = await embedPendingImages(patcher.app, hydrated.data, state.pendingImagePaths);
+				const marked = markUnencryptedFileNodes(embedded.data);
+				if (marked.changed || hydrated.hydratedPaths.length > 0 || embedded.embeddedPaths.length > 0) {
+					this.canvas.setData(marked.data);
+					patcher.decorateUnencryptedNodes(this);
+				}
+				const encrypted = await encryptCanvasData(marked.data, credentials.password, credentials.hint);
+				if (!await verifyEncryptedCanvas(encrypted, credentials.password, marked.data)) {
+					throw new Error('Encrypted Canvas verification failed');
+				}
+				state.wrapperText = encrypted;
+				await original.call(this, clear);
+				if (this.file === null || await patcher.app.vault.read(this.file) !== encrypted) {
+					throw new Error('Encrypted Canvas disk verification failed');
+				}
+				for (const path of embedded.embeddedPaths) {
+					const file = patcher.app.vault.getAbstractFileByPath(path);
+					if (file instanceof TFile) await patcher.app.vault.delete(file, true);
+					state.pendingImagePaths.delete(path);
+				}
+			};
+			state.saveQueue = state.saveQueue.then(queuedSave, queuedSave);
+			try { await state.saveQueue; }
+			catch (error) {
+				console.error('Meld encrypted Canvas save failed', {
+					path: this.file?.path,
+					errorType: error instanceof Error ? error.name : typeof error,
+				});
+				new Notice(`Encrypted Canvas was not saved: ${this.file?.path ?? 'unknown file'}`);
+				throw error;
+			}
+		});
+
+		if (typeof this.prototype?.onUnloadFile === 'function') {
+			this.patch('onUnloadFile', original => async function(this: NativeCanvasView, file: TFile): Promise<void> {
+				try { await original.call(this, file); }
+				finally {
+					if (patcher.openViewsByPath.get(file.path) === this) patcher.openViewsByPath.delete(file.path);
+					patcher.disable(this);
+				}
+			});
+		}
+	}
+
+	private prepareEncryptedLoad(view: NativeCanvasView, wrapperText: string): number | null {
+		if (!this.acceptingLoads) return null;
+		if (view.file === null) return null;
+		const currentState = this.states.get(view);
+		if (currentState?.loadInProgress) return null;
+		this.markProtected(view.file);
+		const existingView = this.openViewsByPath.get(view.file.path);
+		if (existingView !== undefined && existingView !== view) {
+			new Notice(`Encrypted Canvas is already open: ${view.file.path}`);
+			view.leaf.detach();
+			return null;
+		}
+		this.openViewsByPath.set(view.file.path, view);
+		const state: ViewState = currentState ?? {
+			passwordAndHint: null, wrapperText, savingEnabled: false,
+			saveQueue: Promise.resolve(), loadGeneration: 0, loadInProgress: false,
+			pendingImagePaths: new Set(), allowUnencryptedImageUntil: 0,
+		};
+		state.wrapperText = wrapperText;
+		state.savingEnabled = false;
+		state.loadInProgress = true;
+		state.loadGeneration += 1;
+		this.states.set(view, state);
+		return state.loadGeneration;
+	}
+
+	private async unlockAndLoad(
+		view: NativeCanvasView, wrapper: EncryptedCanvasWrapper, wrapperText: string,
+		generation: number, applyData: (data: CanvasData) => void,
+	): Promise<void> {
+		if (!this.acceptingLoads) return;
+		if (view.file === null) return;
+		let credentials = await this.resolvePassword(view.file, wrapper.meldEncryptedCanvas.payload.hint, false);
+		if (!this.acceptingLoads) return;
+		let data = credentials === null ? null : await decryptCanvasData(wrapper, credentials.password);
+		while (credentials !== null && data === null) {
+			new Notice('Decryption failed');
+			credentials = await this.resolvePassword(view.file, wrapper.meldEncryptedCanvas.payload.hint, true);
+			data = credentials === null ? null : await decryptCanvasData(wrapper, credentials.password);
+			if (!this.acceptingLoads) return;
+		}
+		if (credentials === null) {
+			const state = this.states.get(view);
+			if (state?.loadGeneration === generation) state.loadInProgress = false;
+			this.disable(view);
+			view.leaf.detach();
+			return;
+		}
+		const state = this.states.get(view);
+		if (data === null || state === undefined || state.loadGeneration !== generation) {
+			if (state?.loadGeneration === generation) state.loadInProgress = false;
+			new Notice(`Unable to decrypt Canvas: ${view.file.path}`);
+			this.disable(view);
+			view.leaf.detach();
+			return;
+		}
+		const marked = markUnencryptedFileNodes(data);
+		const hydrated = await hydrateEncryptedNotes(this.app, marked.data, credentials.password);
+		if (hydrated.failedPaths.length > 0) new Notice('Some encrypted notes use a different password and remain locked');
+		state.passwordAndHint = credentials;
+		state.wrapperText = wrapperText;
+		state.savingEnabled = true;
+		state.loadInProgress = false;
+		applyData(hydrated.data);
+		this.decorateUnencryptedNodes(view);
+		console.info('Meld encrypted Canvas loaded', { path: view.file.path });
+	}
+
+	decorateUnencryptedNodes(view: NativeCanvasView): void {
+		queueMicrotask(() => {
+			for (const node of view.canvas.nodes?.values() ?? []) {
+				const element = node.nodeEl;
+				if (element === undefined) continue;
+				const data = node.getData?.();
+				const unencrypted = data !== undefined
+					&& (data.meldUnencrypted === true || isUnencryptedFileNodeData(data));
+				element.classList.toggle('meld-canvas-unencrypted', unencrypted);
+				const existingBadge = element.querySelector<HTMLElement>(':scope > .meld-canvas-unencrypted-badge');
+				if (!unencrypted) {
+					existingBadge?.remove();
+					continue;
+				}
+				if (existingBadge === null) {
+					const badge = document.createElement('div');
+					badge.className = 'meld-canvas-unencrypted-badge';
+					badge.textContent = 'UNENCRYPTED';
+					badge.setAttribute('aria-label', 'This Canvas item is stored unencrypted');
+					element.appendChild(badge);
+				}
+			}
+		});
+	}
+
+	private patchVaultWrites(): void {
+		const vault = this.app.vault as typeof this.app.vault & { modify: (file: TFile, data: string, options?: unknown) => Promise<void> };
+		const originalModify = vault.modify;
+		const patcher = this;
+		const guardedVaultModify = async function(file: TFile, data: string, options?: unknown): Promise<void> {
+			if (patcher.isProtected(file) && !isEncryptedCanvasWrapper(data)) {
+				new Notice(`Blocked plaintext write to protected Canvas: ${file.path}`);
+				throw new Error(`Meld blocked a non-encrypted Canvas write to ${file.path}`);
+			}
+			return originalModify.call(this, file, data, options as never);
+		};
+		vault.modify = guardedVaultModify;
+		this.restorers.push(() => { if (vault.modify === guardedVaultModify) vault.modify = originalModify; });
+
+		const adapter = this.app.vault.adapter as typeof this.app.vault.adapter & {
+			write: (path: string, data: string, options?: unknown) => Promise<void>;
+		};
+		const originalAdapterWrite = adapter.write;
+		const guardedAdapterWrite = async function(path: string, data: string, options?: unknown): Promise<void> {
+			if (patcher.protectedPaths.has(path) && !isEncryptedCanvasWrapper(data)) {
+				new Notice(`Blocked adapter plaintext write to protected Canvas: ${path}`);
+				throw new Error(`Meld blocked a non-encrypted adapter write to ${path}`);
+			}
+			return originalAdapterWrite.call(this, path, data, options as never);
+		};
+		adapter.write = guardedAdapterWrite;
+		this.restorers.push(() => { if (adapter.write === guardedAdapterWrite) adapter.write = originalAdapterWrite; });
+
+		const originalAppend = adapter.append;
+		const guardedAppend = async function(path: string, data: string, options?: unknown): Promise<void> {
+			if (patcher.protectedPaths.has(path)) {
+				throw new Error(`Meld blocked append to protected Canvas: ${path}`);
+			}
+			return originalAppend.call(this, path, data, options as never);
+		};
+		adapter.append = guardedAppend;
+		this.restorers.push(() => { if (adapter.append === guardedAppend) adapter.append = originalAppend; });
+
+		const originalWriteBinary = adapter.writeBinary;
+		const guardedWriteBinary = async function(path: string, data: ArrayBuffer, options?: unknown): Promise<void> {
+			if (patcher.protectedPaths.has(path)) {
+				throw new Error(`Meld blocked binary write to protected Canvas: ${path}`);
+			}
+			return originalWriteBinary.call(this, path, data, options as never);
+		};
+		adapter.writeBinary = guardedWriteBinary;
+		this.restorers.push(() => { if (adapter.writeBinary === guardedWriteBinary) adapter.writeBinary = originalWriteBinary; });
+	}
+
+	private patch(name: string, factory: (original: CanvasMethod) => CanvasMethod): void {
+		if (this.prototype === null) return;
+		const hadOwnMethod = Object.prototype.hasOwnProperty.call(this.prototype, name);
+		const original = this.prototype[name];
+		if (typeof original !== 'function') return;
+		const replacement = factory(original);
+		this.prototype[name] = replacement;
+		this.restorers.push(() => {
+			if (this.prototype === null) return;
+			if (this.prototype[name] !== replacement) return;
+			if (hadOwnMethod) this.prototype[name] = original;
+			else delete this.prototype[name];
+		});
+	}
+}

--- a/src/features/feature-canvas-encrypt/CanvasTypes.ts
+++ b/src/features/feature-canvas-encrypt/CanvasTypes.ts
@@ -1,0 +1,55 @@
+import type { TFile, WorkspaceLeaf } from 'obsidian';
+
+export interface CanvasData {
+	nodes: unknown[];
+	edges: unknown[];
+	[key: string]: unknown;
+}
+
+export function assertCanvasData(value: unknown): asserts value is CanvasData {
+	if (typeof value !== 'object' || value === null) throw new Error('Canvas payload is not an object');
+	const candidate = value as Partial<CanvasData>;
+	if (!Array.isArray(candidate.nodes) || !Array.isArray(candidate.edges)) {
+		throw new Error('Canvas payload must contain nodes and edges arrays');
+	}
+}
+
+export interface NativeCanvas {
+	getData(): CanvasData;
+	setData(data: CanvasData): void;
+	requestSave(): void;
+	createTextNode?(options: {
+		pos: { x: number; y: number };
+		size: { width: number; height: number };
+		text: string;
+	}): unknown;
+	posFromEvt?(event: MouseEvent): { x: number; y: number };
+	nodes?: Map<string, {
+		getData?(): Record<string, unknown>;
+		nodeEl?: HTMLElement;
+	}>;
+}
+
+export interface NativeCanvasView {
+	leaf: WorkspaceLeaf;
+	file: TFile | null;
+	canvas: NativeCanvas;
+	getViewType(): string;
+	getViewData(): string;
+	setViewData(data: string, clear: boolean): void;
+	save(clear?: boolean): Promise<void>;
+	onLoadFile?(file: TFile): Promise<void>;
+	onUnloadFile?(file: TFile): Promise<void>;
+	addAction?(icon: string, title: string, callback: () => unknown): HTMLElement;
+}
+
+export function isNativeCanvasView(value: unknown): value is NativeCanvasView {
+	if (typeof value !== 'object' || value === null) return false;
+	const candidate = value as Partial<NativeCanvasView>;
+	return candidate.getViewType?.() === 'canvas'
+		&& typeof candidate.getViewData === 'function'
+		&& typeof candidate.setViewData === 'function'
+		&& typeof candidate.save === 'function'
+		&& typeof candidate.canvas?.getData === 'function'
+		&& typeof candidate.canvas?.setData === 'function';
+}

--- a/src/features/feature-canvas-encrypt/FeatureCanvasEncrypt.ts
+++ b/src/features/feature-canvas-encrypt/FeatureCanvasEncrypt.ts
@@ -1,0 +1,475 @@
+import { Notice, Setting, TFile, TFolder } from 'obsidian';
+import type MeldEncrypt from '../../main.ts';
+import PluginPasswordModal from '../../PluginPasswordModal.ts';
+import { SessionPasswordService, type PasswordAndHint } from '../../services/SessionPasswordService.ts';
+import type { IMeldEncryptPluginSettings } from '../../settings/MeldEncryptPluginSettings.ts';
+import type { IFeatureCanvasEncryptSettings } from './IFeatureCanvasEncryptSettings.ts';
+import type { IMeldEncryptPluginFeature } from '../IMeldEncryptPluginFeature.ts';
+import {
+	decodeEncryptedCanvasWrapper, decryptCanvasData, encryptCanvasData,
+	hasEncryptedCanvasMarker, isEncryptedCanvasWrapper,
+	verifyEncryptedCanvas,
+} from './CanvasEncryptionWrapper.ts';
+import { CanvasPatcher } from './CanvasPatcher.ts';
+import { assertCanvasData, isNativeCanvasView, type CanvasData, type NativeCanvasView } from './CanvasTypes.ts';
+import { CanvasConfirmationModal } from './CanvasConfirmationModal.ts';
+
+export default class FeatureCanvasEncrypt implements IMeldEncryptPluginFeature {
+	private plugin: MeldEncrypt;
+	private featureSettings: IFeatureCanvasEncryptSettings;
+	private patcher: CanvasPatcher;
+	private statusIndicator: HTMLElement;
+	private decoratedViews = new WeakSet<NativeCanvasView>();
+	private disposed = false;
+	private altPressed = false;
+
+	async onload(plugin: MeldEncrypt, settings: IMeldEncryptPluginSettings): Promise<void> {
+		this.disposed = false;
+		this.plugin = plugin;
+		this.featureSettings = settings.featureCanvasEncrypt;
+		this.patcher = new CanvasPatcher(plugin.app, (file, hint, forcePrompt) =>
+			this.resolvePassword(file, hint, forcePrompt));
+		if (!this.featureSettings.enabled) return;
+		this.patcher.installWriteGuard();
+		await this.discoverProtectedFiles();
+		await this.tryBootstrapCanvasPrototype();
+
+		this.statusIndicator = plugin.addStatusBarItem();
+		this.statusIndicator.setText('🔒 Meld Encrypted Canvas');
+		this.statusIndicator.hide();
+
+		const installFromLeaves = (): void => {
+			for (const leaf of plugin.app.workspace.getLeavesOfType('canvas')) {
+				if (this.patcher.tryInstall(leaf.view)) break;
+			}
+		};
+		const initializeCanvasRuntime = async (): Promise<void> => {
+			if (this.disposed) return;
+			await this.discoverProtectedFiles();
+			if (this.disposed) return;
+			installFromLeaves();
+			await this.reloadProtectedOpenViews();
+			this.updateActiveCanvasUi();
+			if (this.patcher.hasProtectedFiles() && !this.patcher.isInstalled()) {
+				new Notice('Encrypted Canvas support is unavailable in this Obsidian version');
+				for (const leaf of plugin.app.workspace.getLeavesOfType('canvas')) leaf.detach();
+			}
+		};
+		if (plugin.app.workspace.layoutReady) await initializeCanvasRuntime();
+		else plugin.app.workspace.onLayoutReady(() => { void initializeCanvasRuntime(); });
+		plugin.registerEvent(plugin.app.workspace.on('active-leaf-change', leaf => {
+			if (leaf !== null && this.patcher.tryInstall(leaf.view)) void this.reloadProtectedOpenViews();
+			this.updateActiveCanvasUi();
+		}));
+		plugin.registerEvent(plugin.app.workspace.on('file-open', file => {
+			if (file?.extension !== 'canvas') return;
+			for (const leaf of plugin.app.workspace.getLeavesOfType('canvas')) {
+				if (isNativeCanvasView(leaf.view) && leaf.view.file === file) this.patcher.tryInstall(leaf.view);
+			}
+			void this.reloadProtectedOpenViews();
+		}));
+		const canvasNodeObserver = new MutationObserver(() => {
+			const candidate = plugin.app.workspace.getMostRecentLeaf()?.view;
+			if (isNativeCanvasView(candidate) && this.patcher.isProtected(candidate.file)) {
+				this.patcher.decorateUnencryptedNodes(candidate);
+			}
+		});
+		canvasNodeObserver.observe(document.body, { childList: true, subtree: true });
+		plugin.register(() => canvasNodeObserver.disconnect());
+		plugin.registerDomEvent(document, 'keydown', event => { this.altPressed = event.altKey; }, true);
+		plugin.registerDomEvent(document, 'keyup', event => { this.altPressed = event.altKey; }, true);
+		plugin.registerDomEvent(window, 'blur', () => { this.altPressed = false; });
+		plugin.registerDomEvent(document, 'paste', event => {
+			const candidate = plugin.app.workspace.getMostRecentLeaf()?.view;
+			if (!isNativeCanvasView(candidate) || !this.patcher.isProtected(candidate.file)) return;
+			const hasImage = Array.from(event.clipboardData?.files ?? []).some(file => file.type.startsWith('image/'));
+			if (hasImage && this.altPressed) {
+				this.patcher.allowNextCreatedImageUnencrypted(candidate);
+				return;
+			}
+			if (!hasImage || typeof candidate.canvas.createTextNode !== 'function') return;
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			void this.patcher.handleImagePaste(candidate, event).then(handled => {
+				if (!handled) new Notice('Encrypted image paste is unavailable in this Obsidian version');
+			});
+		}, true);
+		plugin.registerEvent(plugin.app.vault.on('create', file => {
+			if (!(file instanceof TFile)) return;
+			const candidate = plugin.app.workspace.getMostRecentLeaf()?.view;
+			if (isNativeCanvasView(candidate) && this.patcher.isProtected(candidate.file)) {
+				this.patcher.trackCreatedImage(candidate, file);
+			}
+		}));
+
+		plugin.addCommand({
+			id: 'meld-canvas-encrypt-current-experimental',
+			name: 'Encrypt current Canvas (experimental)',
+			checkCallback: checking => this.withCurrentCanvas(checking, view => this.encryptCurrent(view)),
+		});
+		plugin.addCommand({
+			id: 'meld-canvas-permanently-decrypt-experimental',
+			name: 'Permanently decrypt current Canvas (experimental)',
+			checkCallback: checking => this.withCurrentCanvas(checking, view => this.permanentlyDecrypt(view), true),
+		});
+		plugin.addCommand({
+			id: 'meld-canvas-lock-close-current-experimental',
+			name: 'Lock & Close current encrypted Canvas (experimental)',
+			checkCallback: checking => this.withCurrentCanvas(checking, view => this.lockAndClose(view), true),
+		});
+		plugin.addCommand({
+			id: 'meld-canvas-change-password-experimental',
+			name: 'Change password for encrypted Canvas (experimental)',
+			checkCallback: checking => this.withCurrentCanvas(checking, view => this.changePassword(view), true),
+		});
+		plugin.addCommand({
+			id: 'meld-canvas-lock-close-all-experimental',
+			name: 'Lock & Close all encrypted Canvases (experimental)',
+			callback: async () => { await this.lockAndCloseAll(); },
+		});
+
+		plugin.registerEvent(plugin.app.workspace.on('file-menu', (menu, file) => {
+			if (!(file instanceof TFile) || file.extension !== 'canvas') return;
+			const openView = this.findOpenCanvasView(file);
+			if (!this.patcher.isProtected(file)) {
+				menu.addItem(item => item
+					.setTitle('Meld Encrypt: Encrypt Canvas (experimental)')
+					.setIcon('file-lock-2')
+					.onClick(() => { void (openView === null ? this.encryptClosedFile(file) : this.encryptCurrent(openView)); }));
+				return;
+			}
+			menu.addItem(item => item
+				.setTitle('Meld Encrypt: Change Canvas password (experimental)')
+				.setIcon('key-round')
+				.onClick(() => { void (openView === null ? this.changeClosedFilePassword(file) : this.changePassword(openView)); }));
+			if (openView !== null) {
+				menu.addItem(item => item
+					.setTitle('Meld Encrypt: Lock & Close Canvas (experimental)')
+					.setIcon('lock')
+					.onClick(() => { void this.lockAndClose(openView); }));
+			}
+			menu.addItem(item => item
+				.setTitle('Meld Encrypt: Permanently decrypt Canvas')
+				.setIcon('unlock')
+				.onClick(() => { void (openView === null ? this.permanentlyDecryptClosedFile(file) : this.permanentlyDecrypt(openView)); }));
+		}));
+
+		plugin.registerEvent(plugin.app.vault.on('rename', (file, oldPath) => {
+			if (file instanceof TFile) this.patcher.rename(oldPath, file.path);
+			else if (file instanceof TFolder) this.patcher.renameFolder(oldPath, file.path);
+		}));
+	}
+
+	private findOpenCanvasView(file: TFile): NativeCanvasView | null {
+		for (const leaf of this.plugin.app.workspace.getLeavesOfType('canvas')) {
+			if (isNativeCanvasView(leaf.view) && leaf.view.file === file) return leaf.view;
+		}
+		return null;
+	}
+
+	private async tryBootstrapCanvasPrototype(): Promise<void> {
+		if (this.disposed || this.patcher.isInstalled()) return;
+		try {
+			const leaf = this.plugin.app.workspace.getLeaf(true);
+			await leaf.setViewState({ type: 'canvas', active: false });
+			if (this.disposed) { leaf.detach(); return; }
+			this.patcher.tryInstall(leaf.view);
+			leaf.detach();
+		} catch (error) {
+			console.info('Meld Canvas prototype bootstrap deferred', {
+				errorType: error instanceof Error ? error.name : typeof error,
+			});
+		}
+	}
+
+	private async reloadProtectedOpenViews(): Promise<void> {
+		if (this.disposed) return;
+		for (const leaf of this.plugin.app.workspace.getLeavesOfType('canvas')) {
+			if (!isNativeCanvasView(leaf.view) || leaf.view.file === null
+				|| !this.patcher.isProtected(leaf.view.file)
+				|| this.patcher.hasViewState(leaf.view)) continue;
+			const contents = await this.plugin.app.vault.read(leaf.view.file);
+			if (this.disposed || this.patcher.hasViewState(leaf.view)) continue;
+			leaf.view.setViewData(contents, true);
+		}
+	}
+
+	private updateActiveCanvasUi(): void {
+		const candidate = this.plugin.app.workspace.getMostRecentLeaf()?.view;
+		if (!isNativeCanvasView(candidate) || !this.patcher.isProtected(candidate.file)) {
+			this.statusIndicator?.hide();
+			return;
+		}
+		this.statusIndicator?.show();
+		this.patcher.decorateUnencryptedNodes(candidate);
+		if (this.decoratedViews.has(candidate) || typeof candidate.addAction !== 'function') return;
+		candidate.addAction('lock', 'Lock & Close', () => { void this.lockAndClose(candidate); });
+		candidate.addAction('key-round', 'Change password', () => { void this.changePassword(candidate); });
+		this.decoratedViews.add(candidate);
+	}
+
+	private withCurrentCanvas(
+		checking: boolean,
+		action: (view: NativeCanvasView) => Promise<void>,
+		requireProtected = false,
+	): boolean {
+		const candidate = this.plugin.app.workspace.getMostRecentLeaf()?.view;
+		if (!isNativeCanvasView(candidate) || candidate.file === null
+			|| (requireProtected && !this.patcher.isProtected(candidate.file))) return false;
+		if (!checking) void action(candidate);
+		return true;
+	}
+
+	private async discoverProtectedFiles(): Promise<void> {
+		const files = this.plugin.app.vault.getFiles().filter(file => file.extension === 'canvas');
+		await Promise.all(files.map(async file => {
+			try {
+				const contents = await this.plugin.app.vault.cachedRead(file);
+				if (hasEncryptedCanvasMarker(contents)) {
+					this.patcher.markProtected(file);
+				}
+			} catch (error) {
+				console.error('Meld encrypted Canvas scan failed', { path: file.path, errorType: this.errorType(error) });
+			}
+		}));
+	}
+
+	private async resolvePassword(file: TFile, hint: string, forcePrompt: boolean): Promise<PasswordAndHint | null> {
+		if (this.disposed) return null;
+		if (!forcePrompt) {
+			const cached = await SessionPasswordService.getByFile(file);
+			if (cached.password.length > 0) return { password: cached.password, hint };
+		}
+		const result = await new PluginPasswordModal(
+			this.plugin.app, `Decrypting "${file.basename}"`, false, false,
+			{ password: '', hint },
+		).open2Async();
+		if (result !== null) SessionPasswordService.putByFile(result, file);
+		return result;
+	}
+
+	private async promptForNewPassword(file: TFile, title: string): Promise<PasswordAndHint | null> {
+		return new PluginPasswordModal(
+			this.plugin.app, title, true, true, await SessionPasswordService.getByFile(file),
+		).open2Async();
+	}
+
+	private async encryptCurrent(view: NativeCanvasView): Promise<void> {
+		if (view.file === null) return;
+		try {
+			this.patcher.tryInstall(view);
+			await view.save();
+			const diskBefore = await this.plugin.app.vault.read(view.file);
+			if (isEncryptedCanvasWrapper(diskBefore) || this.patcher.isProtected(view.file)) {
+				new Notice('Canvas is already encrypted');
+				return;
+			}
+			const credentials = await this.promptForNewPassword(view.file, `Encrypting "${view.file.basename}"`);
+			if (credentials === null) return;
+			if (await this.plugin.app.vault.read(view.file) !== diskBefore) {
+				throw new Error('Canvas changed during encryption');
+			}
+			const value: unknown = view.canvas.getData();
+			assertCanvasData(value);
+			const wrapper = await encryptCanvasData(value, credentials.password, credentials.hint);
+			if (!await verifyEncryptedCanvas(wrapper, credentials.password, value)) {
+				throw new Error('Encrypted Canvas verification failed');
+			}
+			this.patcher.markProtected(view.file);
+			try { await this.plugin.app.vault.modify(view.file, wrapper); }
+			catch (error) { this.patcher.unmarkProtected(view.file); throw error; }
+			this.patcher.registerUnlocked(view, wrapper, credentials);
+			SessionPasswordService.putByFile(credentials, view.file);
+			new Notice('Canvas encrypted');
+		} catch (error) {
+			console.error('Meld Canvas encryption failed', { path: view.file.path, errorType: this.errorType(error) });
+			new Notice('Canvas encryption failed; original file was not replaced');
+		}
+	}
+
+	private async encryptClosedFile(file: TFile): Promise<void> {
+		try {
+			const original = await this.plugin.app.vault.read(file);
+			if (isEncryptedCanvasWrapper(original) || this.patcher.isProtected(file)) return;
+			const value: unknown = JSON.parse(original);
+			assertCanvasData(value);
+			const credentials = await this.promptForNewPassword(file, `Encrypting "${file.basename}"`);
+			if (credentials === null) return;
+			const wrapper = await encryptCanvasData(value, credentials.password, credentials.hint);
+			if (!await verifyEncryptedCanvas(wrapper, credentials.password, value)) throw new Error('Verification failed');
+			if (await this.plugin.app.vault.read(file) !== original) throw new Error('Canvas changed during encryption');
+			this.patcher.markProtected(file);
+			try { await this.plugin.app.vault.modify(file, wrapper); }
+			catch (error) { this.patcher.unmarkProtected(file); throw error; }
+			SessionPasswordService.putByFile(credentials, file);
+			new Notice('Canvas encrypted');
+		} catch (error) {
+			console.error('Closed Canvas encryption failed', { path: file.path, errorType: this.errorType(error) });
+			new Notice('Canvas encryption failed; original file was not replaced');
+		}
+	}
+
+	private async lockAndClose(view: NativeCanvasView): Promise<void> {
+		if (view.file === null) return;
+		try {
+			await this.saveLockAndClose(view);
+		} catch {
+			new Notice('Lock & Close aborted because the encrypted save failed');
+		}
+	}
+
+	private async saveLockAndClose(view: NativeCanvasView): Promise<void> {
+		if (view.file === null) return;
+		await view.save();
+		this.patcher.disable(view);
+		SessionPasswordService.clearForFile(view.file);
+		view.leaf.detach();
+	}
+
+	private async lockAndCloseAll(): Promise<void> {
+		for (const leaf of this.plugin.app.workspace.getLeavesOfType('canvas')) {
+			if (!isNativeCanvasView(leaf.view) || !this.patcher.isProtected(leaf.view.file)) continue;
+			try { await this.saveLockAndClose(leaf.view); }
+			catch {
+				new Notice(`Could not lock Canvas: ${leaf.view.file?.path ?? 'unknown file'}`);
+			}
+		}
+	}
+
+	private async changePassword(view: NativeCanvasView): Promise<void> {
+		if (view.file === null) return;
+		try {
+			await view.save();
+			const credentials = await this.promptForNewPassword(view.file, `Change password for "${view.file.basename}"`);
+			if (credentials === null) return;
+			await this.patcher.assertDiskUnchanged(view);
+			const value: unknown = view.canvas.getData();
+			assertCanvasData(value);
+			const wrapper = await encryptCanvasData(value, credentials.password, credentials.hint);
+			if (!await verifyEncryptedCanvas(wrapper, credentials.password, value)) throw new Error('Verification failed');
+			await this.plugin.app.vault.modify(view.file, wrapper);
+			this.patcher.registerUnlocked(view, wrapper, credentials);
+			SessionPasswordService.putByFile(credentials, view.file);
+			new Notice('Canvas password changed');
+		} catch (error) {
+			console.error('Meld Canvas password change failed', { path: view.file.path, errorType: this.errorType(error) });
+			new Notice('Canvas password was not changed');
+		}
+	}
+
+	private async decryptClosedFile(file: TFile): Promise<{ data: CanvasData; wrapperText: string } | null> {
+		const wrapperText = await this.plugin.app.vault.read(file);
+		const wrapper = decodeEncryptedCanvasWrapper(wrapperText);
+		if (wrapper === null) throw new Error('Encrypted Canvas wrapper is invalid');
+		let credentials = await this.resolvePassword(file, wrapper.meldEncryptedCanvas.payload.hint, false);
+		let data = credentials === null ? null : await decryptCanvasData(wrapper, credentials.password);
+		while (credentials !== null && data === null) {
+			new Notice('Decryption failed');
+			credentials = await this.resolvePassword(file, wrapper.meldEncryptedCanvas.payload.hint, true);
+			data = credentials === null ? null : await decryptCanvasData(wrapper, credentials.password);
+		}
+		return data === null ? null : { data, wrapperText };
+	}
+
+	private async changeClosedFilePassword(file: TFile): Promise<void> {
+		try {
+			const decrypted = await this.decryptClosedFile(file);
+			if (decrypted === null) return;
+			const credentials = await this.promptForNewPassword(file, `Change password for "${file.basename}"`);
+			if (credentials === null) return;
+			const wrapper = await encryptCanvasData(decrypted.data, credentials.password, credentials.hint);
+			if (!await verifyEncryptedCanvas(wrapper, credentials.password, decrypted.data)) throw new Error('Verification failed');
+			if (await this.plugin.app.vault.read(file) !== decrypted.wrapperText) throw new Error('Canvas changed externally');
+			await this.plugin.app.vault.modify(file, wrapper);
+			SessionPasswordService.putByFile(credentials, file);
+			new Notice('Canvas password changed');
+		} catch (error) {
+			console.error('Closed Canvas password change failed', { path: file.path, errorType: this.errorType(error) });
+			new Notice('Canvas password was not changed');
+		}
+	}
+
+	private async permanentlyDecrypt(view: NativeCanvasView): Promise<void> {
+		if (view.file === null) return;
+		const confirmed = await new CanvasConfirmationModal(
+			this.plugin.app,
+			'Permanently decrypt Canvas?',
+			'This writes the complete decrypted Canvas permanently to disk. This cannot be undone by Meld Encrypt.',
+			'Write plaintext to disk',
+		).openAsync();
+		if (!confirmed) return;
+		try {
+			await view.save();
+			await this.patcher.assertDiskUnchanged(view);
+			const value: unknown = view.canvas.getData();
+			assertCanvasData(value);
+			const plaintext = JSON.stringify(value, null, 2);
+			this.patcher.unmarkProtected(view.file);
+			try { await this.plugin.app.vault.modify(view.file, plaintext); }
+			catch (error) { this.patcher.markProtected(view.file); throw error; }
+			this.patcher.disable(view);
+			SessionPasswordService.clearForFile(view.file);
+			this.statusIndicator.hide();
+			new Notice('Canvas permanently decrypted');
+		} catch (error) {
+			console.error('Permanent Canvas decryption failed', { path: view.file.path, errorType: this.errorType(error) });
+			new Notice('Canvas was not permanently decrypted');
+		}
+	}
+
+	private async permanentlyDecryptClosedFile(file: TFile): Promise<void> {
+		const confirmed = await new CanvasConfirmationModal(
+			this.plugin.app, 'Permanently decrypt Canvas?',
+			'This writes the complete decrypted Canvas permanently to disk. This cannot be undone by Meld Encrypt.',
+			'Write plaintext to disk',
+		).openAsync();
+		if (!confirmed) return;
+		try {
+			const decrypted = await this.decryptClosedFile(file);
+			if (decrypted === null) return;
+			if (await this.plugin.app.vault.read(file) !== decrypted.wrapperText) throw new Error('Canvas changed externally');
+			const plaintext = JSON.stringify(decrypted.data, null, 2);
+			this.patcher.unmarkProtected(file);
+			try { await this.plugin.app.vault.modify(file, plaintext); }
+			catch (error) { this.patcher.markProtected(file); throw error; }
+			SessionPasswordService.clearForFile(file);
+			new Notice('Canvas permanently decrypted');
+		} catch (error) {
+			console.error('Closed Canvas permanent decryption failed', { path: file.path, errorType: this.errorType(error) });
+			new Notice('Canvas was not permanently decrypted');
+		}
+	}
+
+	async onunload(): Promise<void> {
+		this.disposed = true;
+		this.patcher.stopAcceptingLoads();
+		try {
+			for (const leaf of this.plugin.app.workspace.getLeavesOfType('canvas')) {
+				if (!isNativeCanvasView(leaf.view) || !this.patcher.isProtected(leaf.view.file)) continue;
+				try { await this.saveLockAndClose(leaf.view); }
+				catch {
+					new Notice(`Could not lock Canvas: ${leaf.view.file?.path ?? 'unknown file'}`);
+				}
+			}
+		} finally {
+			this.patcher?.uninstall();
+		}
+	}
+	private errorType(error: unknown): string { return error instanceof Error ? error.name : typeof error; }
+
+	buildSettingsUi(containerEl: HTMLElement, saveSettingCallback: () => Promise<void>): void {
+		new Setting(containerEl)
+			.setHeading()
+			.setName('Encrypted Canvas (experimental)');
+		new Setting(containerEl)
+			.setName('Enable encrypted Canvas support')
+			.setDesc('Adds commands and menu actions to encrypt .canvas files. Experimental: '
+				+ 'patches Obsidian\'s internal Canvas view. Restart Obsidian after changing this setting.')
+			.addToggle(toggle => toggle
+				.setValue(this.featureSettings.enabled)
+				.onChange(async value => {
+					this.featureSettings.enabled = value;
+					await saveSettingCallback();
+				}));
+	}
+}

--- a/src/features/feature-canvas-encrypt/IFeatureCanvasEncryptSettings.ts
+++ b/src/features/feature-canvas-encrypt/IFeatureCanvasEncryptSettings.ts
@@ -1,0 +1,3 @@
+export interface IFeatureCanvasEncryptSettings {
+	enabled: boolean;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { SessionPasswordService } from './services/SessionPasswordService.ts';
 import FeatureInplaceEncrypt from './features/feature-inplace-encrypt/FeatureInplaceEncrypt.ts';
 import FeatureConvertNote from './features/feature-convert-note/FeatureConvertNote.ts';
 import FeatureWholeNoteEncryptV2 from './features/feature-whole-note-encrypt/FeatureWholeNoteEncrypt.ts';
+import FeatureCanvasEncrypt from './features/feature-canvas-encrypt/FeatureCanvasEncrypt.ts';
 
 export default class MeldEncrypt extends Plugin {
 
@@ -14,7 +15,7 @@ export default class MeldEncrypt extends Plugin {
 	private enabledFeatures : IMeldEncryptPluginFeature[] = [];
 
 	async onload() {
-		
+
 		SessionPasswordService.init(this.app.vault.adapter);
 
 		// Settings
@@ -24,6 +25,7 @@ export default class MeldEncrypt extends Plugin {
 			new FeatureWholeNoteEncryptV2(),
 			new FeatureConvertNote(),
 			new FeatureInplaceEncrypt(),
+			new FeatureCanvasEncrypt(),
 		);
 
 		this.addSettingTab(
@@ -47,21 +49,21 @@ export default class MeldEncrypt extends Plugin {
 		});
 
 		// load features
-		this.enabledFeatures.forEach(async f => {
-			await f.onload( this, this.settings );
-		});
+		for (const feature of this.enabledFeatures) {
+			await feature.onload(this, this.settings);
+		}
 
 	}
-	
-	override onunload() {
-		this.enabledFeatures.forEach(async f => {
-			f.onunload();
-		});
+
+	override async onunload(): Promise<void> {
+		for (const feature of [...this.enabledFeatures].reverse()) {
+			await feature.onunload();
+		}
 		super.onunload();
 	}
 
 	async loadSettings() {
-		
+
 		const DEFAULT_SETTINGS: IMeldEncryptPluginSettings = {
 			confirmPassword: true,
 			rememberPassword: true,
@@ -71,11 +73,15 @@ export default class MeldEncrypt extends Plugin {
 
 			featureWholeNoteEncrypt: {
 			},
-			
+
 			featureInplaceEncrypt:{
 				expandToWholeLines: false,
 				markerSearchLimit: 10000,
 				showMarkerWhenReadingDefault: true
+			},
+
+			featureCanvasEncrypt: {
+				enabled: true
 			}
 		}
 

--- a/src/settings/MeldEncryptPluginSettings.ts
+++ b/src/settings/MeldEncryptPluginSettings.ts
@@ -1,5 +1,6 @@
 import { IFeatureInplaceEncryptSettings } from "../features/feature-inplace-encrypt/IFeatureInplaceEncryptSettings.ts";
 import { IFeatureWholeNoteEncryptSettings } from "../features/feature-whole-note-encrypt/IFeatureWholeNoteEncryptSettings.ts";
+import { IFeatureCanvasEncryptSettings } from "../features/feature-canvas-encrypt/IFeatureCanvasEncryptSettings.ts";
 
 export interface IMeldEncryptPluginSettings {
 	confirmPassword: boolean;
@@ -10,5 +11,6 @@ export interface IMeldEncryptPluginSettings {
 
 	featureWholeNoteEncrypt : IFeatureWholeNoteEncryptSettings;
 	featureInplaceEncrypt : IFeatureInplaceEncryptSettings;
+	featureCanvasEncrypt : IFeatureCanvasEncryptSettings;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,3 +26,22 @@ div[data-type="meld-encrypted-view"] .view-content {
 }
 
 /* END FEATURE ENCRYPTED MD */
+.canvas-node.meld-canvas-unencrypted {
+	box-shadow: 0 0 0 2px var(--color-orange);
+}
+
+.meld-canvas-unencrypted-badge {
+	position: absolute;
+	top: -22px;
+	left: 0;
+	z-index: 20;
+	padding: 2px 6px;
+	border: 1px solid var(--color-orange);
+	border-radius: 4px;
+	background: var(--background-primary);
+	color: var(--color-orange);
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+	pointer-events: none;
+}

--- a/tests/canvas-encryption-wrapper.test.ts
+++ b/tests/canvas-encryption-wrapper.test.ts
@@ -1,0 +1,71 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+	decodeEncryptedCanvasWrapper,
+	decryptCanvasData,
+	encryptCanvasData,
+	hasEncryptedCanvasMarker,
+	isEncryptedCanvasWrapper,
+	verifyEncryptedCanvas,
+} from '../src/features/feature-canvas-encrypt/CanvasEncryptionWrapper.ts';
+import type { CanvasData } from '../src/features/feature-canvas-encrypt/CanvasTypes.ts';
+
+const canvas: CanvasData = {
+	nodes: [{ id: 'n1', type: 'text', text: 'Geheimnis 🔐 äöü', custom: { future: true } }],
+	edges: [{ id: 'e1', label: 'private edge' }],
+	futureTopLevelProperty: ['preserved'],
+};
+
+test('encrypts and losslessly decrypts the complete Canvas payload', async () => {
+	const encoded = await encryptCanvasData(canvas, 'correct horse battery staple', 'test hint');
+	assert.equal(isEncryptedCanvasWrapper(encoded), true);
+	assert.equal(encoded.includes('Geheimnis'), false);
+	assert.equal(encoded.includes('private edge'), false);
+	const wrapper = decodeEncryptedCanvasWrapper(encoded);
+	assert.notEqual(wrapper, null);
+	assert.deepEqual(await decryptCanvasData(wrapper!, 'correct horse battery staple'), canvas);
+	assert.equal(await verifyEncryptedCanvas(encoded, 'correct horse battery staple', canvas), true);
+});
+
+test('wrong passwords do not produce Canvas data', async () => {
+	const encoded = await encryptCanvasData(canvas, 'right password', 'hint');
+	const wrapper = decodeEncryptedCanvasWrapper(encoded);
+	assert.notEqual(wrapper, null);
+	assert.equal(await decryptCanvasData(wrapper!, 'wrong password'), null);
+});
+
+test('recognizes a damaged format marker but rejects it as a writable wrapper', () => {
+	const damaged = JSON.stringify({
+		nodes: [], edges: [],
+		meldEncryptedCanvas: { format: 'meld-encrypted-canvas', version: 999 },
+	});
+	assert.equal(hasEncryptedCanvasMarker(damaged), true);
+	assert.equal(isEncryptedCanvasWrapper(damaged), false);
+});
+
+test('rejects corrupt authenticated ciphertext without returning partial data', async () => {
+	const encoded = await encryptCanvasData(canvas, 'password', 'hint');
+	const parsed = JSON.parse(encoded) as {
+		meldEncryptedCanvas: { payload: { encodedData: string } };
+	};
+	parsed.meldEncryptedCanvas.payload.encodedData =
+		parsed.meldEncryptedCanvas.payload.encodedData.slice(0, -8) + 'AAAAAAAA';
+	const wrapper = decodeEncryptedCanvasWrapper(JSON.stringify(parsed));
+	assert.notEqual(wrapper, null);
+	assert.equal(await decryptCanvasData(wrapper!, 'password'), null);
+});
+
+for (const size of [100_000, 1_000_000, 5_000_000, 10_000_000]) {
+	test(`roundtrips a ${size}-byte-class Canvas`, { timeout: 30_000 }, async () => {
+		const large: CanvasData = {
+			nodes: [{ id: 'large', type: 'text', text: 'X'.repeat(size) }],
+			edges: [],
+		};
+		const started = performance.now();
+		const encoded = await encryptCanvasData(large, 'performance password', '');
+		const wrapper = decodeEncryptedCanvasWrapper(encoded);
+		assert.notEqual(wrapper, null);
+		assert.deepEqual(await decryptCanvasData(wrapper!, 'performance password'), large);
+		assert.ok(performance.now() - started < 30_000);
+	});
+}

--- a/tools/canvas-security-watch.mjs
+++ b/tools/canvas-security-watch.mjs
@@ -1,0 +1,54 @@
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const [vaultArg, canvasArg, markerArg = 'MELD_CANVAS_TEST_SECRET_93c5421', durationArg = '60', intervalArg = '200'] = process.argv.slice(2);
+if (!vaultArg || !canvasArg) {
+	console.error('Usage: npm run test:canvas-security-watch -- <vault> <canvas-relative-path> [marker] [seconds] [interval-ms]');
+	process.exit(2);
+}
+
+const vault = path.resolve(vaultArg);
+const canvasPath = path.resolve(vault, canvasArg);
+const durationMs = Number(durationArg) * 1000;
+const intervalMs = Number(intervalArg);
+const failures = [];
+let samples = 0;
+
+function inspectWrapper(text) {
+	if (text.includes(markerArg)) throw new Error('plaintext marker present in Canvas file');
+	const value = JSON.parse(text);
+	if (!Array.isArray(value.nodes) || value.nodes.length !== 0) throw new Error('wrapper nodes are not empty');
+	if (!Array.isArray(value.edges) || value.edges.length !== 0) throw new Error('wrapper edges are not empty');
+	if (value.meldEncryptedCanvas?.format !== 'meld-encrypted-canvas') throw new Error('encrypted marker missing');
+	if (value.meldEncryptedCanvas?.version !== 1) throw new Error('unsupported wrapper version');
+}
+
+async function scanTree(directory) {
+	for (const entry of await readdir(directory, { withFileTypes: true })) {
+		const absolute = path.join(directory, entry.name);
+		if (entry.isDirectory()) {
+			await scanTree(absolute);
+			continue;
+		}
+		const bytes = await readFile(absolute);
+		if (bytes.includes(Buffer.from(markerArg))) failures.push(`plaintext marker found: ${absolute}`);
+	}
+}
+
+const deadline = Date.now() + durationMs;
+while (Date.now() < deadline) {
+	try {
+		inspectWrapper(await readFile(canvasPath, 'utf8'));
+		samples += 1;
+	} catch (error) {
+		failures.push(`sample ${samples + 1}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	await new Promise(resolve => setTimeout(resolve, intervalMs));
+}
+
+await scanTree(vault);
+if (failures.length > 0) {
+	console.error(JSON.stringify({ ok: false, samples, failures }, null, 2));
+	process.exit(1);
+}
+console.log(JSON.stringify({ ok: true, samples, vault, canvasPath, marker: markerArg }, null, 2));

--- a/tools/create-encrypted-canvas-fixture.ts
+++ b/tools/create-encrypted-canvas-fixture.ts
@@ -1,0 +1,32 @@
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { encryptCanvasData } from '../src/features/feature-canvas-encrypt/CanvasEncryptionWrapper.ts';
+import type { CanvasData } from '../src/features/feature-canvas-encrypt/CanvasTypes.ts';
+
+const [outputArg, password = 'meld-canvas-runtime-test-password'] = process.argv.slice(2);
+if (!outputArg) {
+	console.error('Usage: npm run test:canvas-fixture -- <output.canvas> [password]');
+	process.exit(2);
+}
+
+async function main(): Promise<void> {
+	const marker = ['MELD_CANVAS_TEST', 'SECRET_93c5421'].join('_');
+	const data: CanvasData = {
+	nodes: [
+		{ id: 'text', type: 'text', text: marker, x: 0, y: 0, width: 400, height: 200 },
+		{ id: 'link', type: 'link', url: `https://example.invalid/${marker}`, x: 500, y: 0, width: 400, height: 200 },
+		{ id: 'group', type: 'group', label: marker, x: -50, y: -50, width: 1000, height: 400 },
+	],
+	edges: [{ id: 'edge', fromNode: 'text', toNode: 'link', label: marker }],
+		futureProperty: { marker, preserved: true },
+	};
+
+	const wrapper = await encryptCanvasData(data, password, 'runtime-test');
+	await writeFile(resolve(outputArg), wrapper, { encoding: 'utf8', flag: 'wx' });
+	console.log(JSON.stringify({ output: resolve(outputArg), password, plaintextBytes: JSON.stringify(data).length }));
+}
+
+void main().catch(error => {
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/tools/obsidian-cdp-eval.mjs
+++ b/tools/obsidian-cdp-eval.mjs
@@ -1,0 +1,39 @@
+const [expression, port = '9223'] = process.argv.slice(2);
+if (!expression) {
+	console.error('Usage: node tools/obsidian-cdp-eval.mjs <javascript-expression> [port]');
+	process.exit(2);
+}
+
+const targets = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json();
+const page = targets.find(target => target.type === 'page');
+if (!page) throw new Error('No Obsidian page target found');
+
+const socket = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+	socket.addEventListener('open', resolve, { once: true });
+	socket.addEventListener('error', reject, { once: true });
+});
+
+const id = 1;
+socket.send(JSON.stringify({
+	id,
+	method: 'Runtime.evaluate',
+	params: { expression, awaitPromise: true, returnByValue: true },
+}));
+
+const response = await new Promise((resolve, reject) => {
+	const timer = setTimeout(() => reject(new Error('CDP evaluation timed out')), 30_000);
+	socket.addEventListener('message', event => {
+		const message = JSON.parse(event.data);
+		if (message.id !== id) return;
+		clearTimeout(timer);
+		resolve(message);
+	});
+});
+socket.close();
+
+if (response.result?.exceptionDetails) {
+	console.error(JSON.stringify({ exception: response.result.exceptionDetails.text }));
+	process.exit(1);
+}
+console.log(JSON.stringify(response.result?.result?.value ?? null));


### PR DESCRIPTION
## Summary

- add encryption and decryption support for Obsidian Canvas files
- add canvas patching, embedded-content handling, confirmation UI, and settings integration
- add documentation, security test tooling, and wrapper tests

## Testing

- Not run in this environment because npm is unavailable
- git diff --check passed before commit